### PR TITLE
Derive rust toolchain from ruby

### DIFF
--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -17,11 +17,27 @@ jobs:
             ref: main
             run: bundle exec rake
           - name: "matsadler/magnus"
-            ref: main
+            ref: 855cc11a73e536083e37bb89d5e101a02a748150
             run: cargo test
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["2.7", "3.0", "3.1", "head"]
+        include:
+          - os: "windows-latest"
+            ruby: "mswin"
+            rust: "stable"
+            repo:
+              name: "oxidize-rb/oxi-test"
+              ref: main
+              run: bundle exec rake
+          # - os: "windows-latest"
+          #   ruby: "mswin"
+          #   rust: "stable"
+          #   repo:
+          #     name: "matsadler/magnus"
+          #     ref: 855cc11a73e536083e37bb89d5e101a02a748150
+          #     run: env RUSTFLAGS="-Clink-dead-code=off" cargo test
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -32,11 +48,16 @@ jobs:
         with:
           path: ./tmp/actions
       - uses: ./tmp/actions/setup-ruby-and-rust
+        id: setup
         with:
           ruby-version: ${{ matrix.ruby }}
+          rustup-toolchain: ${{ matrix.rust }}
+          cache-version: v1
           bundler-cache: true
           cargo-cache: true
-          cache-version: v1
-          rustup-toolchain: ${{ matrix.rust }}
+      - name: Run unit tests
+        env:
+          SETUP_OUTPUTS: ${{ toJSON(steps.setup.outputs) }}
+        run: ruby ./tmp/actions/setup-ruby-and-rust/test.rb -v
       - name: Run tests for ${{ matrix.repo.name }}
         run: ${{ matrix.repo.run }}

--- a/fetch-ci-data/action.yml
+++ b/fetch-ci-data/action.yml
@@ -26,5 +26,6 @@ runs:
       id: run-query
       shell: bash
       run: |
-        result="$(echo '${{ toJSON(inputs) }}' | ruby $GITHUB_ACTION_PATH/evaluate.rb)"  
+        : Run query
+        result="$(echo '${{ toJSON(inputs) }}' | ruby $GITHUB_ACTION_PATH/evaluate.rb)"
         echo "result=$result">> $GITHUB_OUTPUT

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -49,9 +49,9 @@ outputs:
   ruby-prefix:
     description: "The prefix of the installed ruby"
     value: ${{ steps.set-outputs.outputs.ruby-prefix }}
-  ruby-arch:
-    description: "The arch of the installed ruby"
-    value: ${{ steps.set-outputs.outputs.ruby-arch }}
+  ruby-platform:
+    description: "The platform of the installed ruby"
+    value: ${{ steps.set-outputs.outputs.ruby-platform }}
   cache-key:
     description: "Derived cache key for the current environment"
     value: ${{ steps.set-outputs.outputs.cache-key }}
@@ -69,19 +69,29 @@ runs:
     - name: Install helpers
       shell: bash
       run: |
+        : Install helpers
         echo "$GITHUB_ACTION_PATH/bin" >> $GITHUB_PATH
 
     - name: Print rbconfig
       shell: bash
       run: |
+        : Print rbconfig
         echo "::group::Print rbconfig below"
         rbconfig
         echo "::endgroup::"
 
+    - name: Derive toolchain
+      id: derive-toolchain
+      shell: bash
+      run: |
+        : Derive toolchain
+        derived_toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb ${{ inputs.rustup-toolchain }})"
+        echo "toolchain=$derived_toolchain" >> $GITHUB_OUTPUT
+
     - uses: dtolnay/rust-toolchain@master
       id: rust-toolchain
       with:
-        toolchain: ${{ (runner.os == 'Windows' && format('{0}-x86_64-pc-windows-gnu', inputs.rustup-toolchain)) || inputs.rustup-toolchain }}
+        toolchain: ${{ steps.derive-toolchain.outputs.toolchain }}
         targets: ${{ inputs.rustup-targets }}
         components: ${{ inputs.rustup-components }}
 
@@ -89,9 +99,11 @@ runs:
       id: set-outputs
       shell: bash
       run: |
+        : Set outputs
+        ruby_platform="$(rbconfig arch)"
         echo "ruby-prefix=$(rbconfig prefix)" >> $GITHUB_OUTPUT
-        echo "ruby-arch=$(rbconfig arch)" >> $GITHUB_OUTPUT
-        echo "cache-key=setup-ruby-and-ruby-${{ inputs.cache-version }}-ruby-$(rbconfig arch)-$(rbconfig ruby_version)-rust-${{ steps.rust-toolchain.outputs.cachekey }}-${{ hashFiles('**/Cargo.lock', '**/extconf.rb', '**/Gemfile.lock') }}" >> $GITHUB_OUTPUT
+        echo "ruby-platform=$ruby_platform" >> $GITHUB_OUTPUT
+        echo "cache-key=$(rbconfig ruby_version)__${ruby_platform}__${{ steps.rust-toolchain.outputs.cachekey }}__${{ hashFiles('**/Cargo.lock', '**/extconf.rb', '**/Gemfile.lock') }}__${{ inputs.cache-version }}" >> $GITHUB_OUTPUT
 
     - name: Setup cargo cache
       uses: actions/cache@v3
@@ -103,22 +115,22 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
           **/target/
-          **/tmp/${{ steps.set-outputs.outputs.ruby-arch }}/
+          **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/
           ${{ inputs.cargo-cache-extra-path }}
         key: ${{ steps.set-outputs.outputs.cache-key }}
 
-    # Enable when mswin is supported
-    # - name: Fixup paths
-    #   if: runner.os == 'Windows'
+    # - name: Set LIBCLANG_PATH
+    #   if: contains('mswin', steps.set-outputs.outputs.ruby-platform)
     #   shell: pwsh
     #   working-directory: ${{ inputs.working-directory }}
     #   run: |
     #     echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
 
-    - name: Fix LD_LIBRARY_PATH for Ruby
+    - name: Set LD_LIBRARY_PATH for Ruby
       if: runner.os == 'Linux'
       shell: bash
       run: |
+        : Set LD_LIBRARY_PATH for Ruby
         echo "::group::Adding Ruby libdir to LD_LIBRARY_PATH"
         libdir="$(rbconfig libdir)"
         echo "Ruby libdir is $libdir"
@@ -132,10 +144,11 @@ runs:
         fi
         echo "::endgroup::"
 
-    - name: Vendoring cargo dependencies
+    - name: Vendor cargo dependencies
       if: inputs.cargo-vendor == 'true'
       shell: bash
       run: |
+        : Vendor carogo dependencies
         echo "::group::Vendoring cargo deps"
         [ "${{ inputs.working-directory }}" != "" ] && pushd "${{ inputs.working-directory }}"
         mkdir -p .cargo tmp && cargo vendor "$PWD/tmp/cargo-vendor" >> .cargo/config.toml
@@ -145,6 +158,7 @@ runs:
     - name: Configure environment
       shell: bash
       run: |
+        : Configure environment
         echo "::group::Configuring environment"
 
         if [ "${{ inputs.debug }}" = "true" ]; then

--- a/setup-ruby-and-rust/helpers/derive_toolchain.rb
+++ b/setup-ruby-and-rust/helpers/derive_toolchain.rb
@@ -1,0 +1,16 @@
+require "rbconfig"
+
+def derive_rust_toolchain_from_rbconfig(input_rust_toolchain)
+  return input_rust_toolchain if input_rust_toolchain.count("-") >= 3 # already a full toolchain
+
+  case RbConfig::CONFIG["host_os"]
+  when /mingw/
+    "#{input_rust_toolchain}-x86_64-pc-windows-gnu"
+  when /mswin/
+    "#{input_rust_toolchain}-x86_64-pc-windows-msvc"
+  else
+    input_rust_toolchain
+  end
+end
+
+puts derive_rust_toolchain_from_rbconfig(ARGV.first)

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -66,10 +66,10 @@ jobs:
 
 <!-- outputs -->
 
-| Name            | Description                                   |
-| --------------- | --------------------------------------------- |
-| **cache-key**   | Derived cache key for the current environment |
-| **ruby-arch**   | The arch of the installed ruby                |
-| **ruby-prefix** | The prefix of the installed ruby              |
+| Name              | Description                                   |
+| ----------------- | --------------------------------------------- |
+| **cache-key**     | Derived cache key for the current environment |
+| **ruby-platform** | The platform of the installed ruby            |
+| **ruby-prefix**   | The prefix of the installed ruby              |
 
 <!-- /outputs -->

--- a/setup-ruby-and-rust/test.rb
+++ b/setup-ruby-and-rust/test.rb
@@ -1,0 +1,30 @@
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "maxitest"
+end
+
+require "maxitest/autorun"
+require "json"
+
+OUTPUTS = JSON.parse(ENV.fetch("SETUP_OUTPUTS"))
+
+describe "setup-ruby-and-ruby" do
+  describe "output validation" do
+    it "has has a valid cache-key" do
+      parts = OUTPUTS["cache-key"].split("__")
+
+      assert_equal 5, parts.size
+      assert parts.all? { |part| !part.strip.empty? }
+    end
+
+    it "has has a valid ruby-platform" do
+      assert_equal RbConfig::CONFIG["arch"], OUTPUTS["ruby-platform"]
+    end
+
+    it "has has a valid ruby-prefix" do
+      assert_equal RbConfig::CONFIG["prefix"], OUTPUTS["ruby-prefix"]
+    end
+  end
+end


### PR DESCRIPTION
This will make things like `ruby-version: mswin` work properly, with not hassle.