### PR TITLE
Expose `rubygems` config

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -12,6 +12,10 @@ inputs:
   bundler-cache:
     description: 'Run "bundle install", and cache the result automatically. Either true or false.'
     default: "false"
+  rubygems:
+    description: "Runs `gem update --system`. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info."
+    required: false
+    default: 'default'
   working-directory:
     description: "The working directory to use for resolving paths for .ruby-version, .tool-versions and Gemfile.lock."
   cache-version:
@@ -64,6 +68,7 @@ runs:
         bundler-cache: ${{ inputs.bundler-cache }}
         working-directory: ${{ inputs.working-directory }}
         cache-version: ${{ inputs.cache-version }}
+        rubygems: ${{ inputs.rubygems }}
         mingw: clang
 
     - name: Install helpers

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -55,6 +55,7 @@ jobs:
 | **debug**                  | Enable verbose debugging info (includes summary of action)                                                                       | `false`           |
 | **prefer-ruby-static**     | Prefer using libruby static if it's available                                                                                    | `false`           |
 | **ruby-version**           | Engine and version to use, see the syntax in the README. Reads from .ruby-version or .tool-versions if unset.                    | `default`         |
+| **rubygems**               | Runs `gem update --system`. See [ruby/setup-rub](https://github.com/ruby/setup-ruby/blob/master/README.md) for more info.        | `default`         |
 | **rustup-components**      | Comma-separated string of additional components to install e.g. clippy, rustfmt                                                  | `clippy, rustfmt` |
 | **rustup-targets**         | Comma-separated string of additional targets to install e.g. wasm32-unknown-unknown                                              |                   |
 | **rustup-toolchain**       | Rustup toolchain specifier e.g. stable, nightly, 1.42.0, nightly-2022-01-01.                                                     | `stable`          |


### PR DESCRIPTION
@ianks For folks (like me!) who want gems to be installed on RubyGems > 3.3.21, it would be useful to expose this `rubygems` config, which [ruby/setup-ruby-pkgs](https://github.com/ruby/setup-ruby-pkgs/blob/6c7ccc429f38d583591e5547ebc29c8a45205313/action.yml#L30) provides.

