### PR TITLE
Default to `sccache` for caching

### DIFF
--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -7,7 +7,7 @@ on:
       - ".github/workflows/test-setup-ruby-and-rust.yml"
 jobs:
   test:
-    name: ${{ runner.os }} ${{ matrix.repo.slug }} ${{ matrix.ruby }} ${{ matrix.cargo-cache }}
+    name: ${{ matrix.os }} ${{ matrix.repo.slug }} ${{ matrix.ruby }} ${{ matrix.cargo-cache }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - "setup-ruby-and-rust/**/*"
       - ".github/workflows/test-setup-ruby-and-rust.yml"
+env:
+  SCCACHE_LOG: debug
 jobs:
   test:
     name: ${{ matrix.os }} ${{ matrix.repo.slug }} ${{ matrix.ruby }} ${{ matrix.cargo-cache }}

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -44,14 +44,10 @@ jobs:
     steps:
       - name: Log inputs
         shell: bash
+        env:
+          INPUTS: ${{ toJSON(inputs) }}
         run: |
-          echo "OS: ${{ matrix.os }}"
-          echo "Ruby: ${{ matrix.ruby }}"
-          echo "Rust: ${{ matrix.rust }}"
-          echo "Repo: ${{ matrix.repo.name }}"
-          echo "Ref: ${{ matrix.repo.ref }}"
-          echo "Run: ${{ matrix.repo.run }}"
-          echo "sccache: ${{ matrix.repo.sccache }}"
+          echo "$INPUTS" | jq
       - uses: actions/checkout@v3
         with:
           repository: ${{ matrix.repo.name }}

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -25,7 +25,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["2.7", "3.0", "3.1", "head"]
-        cargo-cache: ["sccache"]
+        cargo-cache: ["true"]
         include:
           - os: "ubuntu-latest"
             ruby: "3.1"
@@ -39,7 +39,7 @@ jobs:
           - os: "windows-latest"
             ruby: "mswin"
             rust: "stable"
-            cargo-cache: "sccache"
+            cargo-cache: "true"
             repo:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
@@ -49,7 +49,7 @@ jobs:
             slug: magnus
             ruby: "mswin"
             rust: "stable"
-            cargo-cache: "sccache"
+            cargo-cache: "true"
             repo:
               name: "matsadler/magnus"
               ref: main

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -7,15 +7,17 @@ on:
       - ".github/workflows/test-setup-ruby-and-rust.yml"
 jobs:
   test:
-    name: ${{ matrix.os }} | ${{ matrix.repo.name }} - ${{ matrix.ruby }} - ${{ matrix.rust }}
+    name: ${{ runner.os }} ${{ matrix.repo.slug }} ${{ matrix.ruby }} ${{ matrix.cargo-cache }}
     strategy:
       fail-fast: false
       matrix:
         repo:
           - name: "oxidize-rb/oxi-test"
+            slug: oxi-test
             ref: main
             run: bundle exec rake
           - name: "matsadler/magnus"
+            slug: magnus
             ref: 855cc11a73e536083e37bb89d5e101a02a748150
             run: cargo test
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
@@ -28,10 +30,12 @@ jobs:
             rust: "stable"
             repo:
               name: "oxidize-rb/oxi-test"
+              slug: oxi-test
               ref: main
               run: bundle exec rake
               cargo-cache: "sccache"
           - os: "windows-latest"
+            slug: magnus
             ruby: "mswin"
             rust: "stable"
             repo:
@@ -62,9 +66,8 @@ jobs:
           rustup-toolchain: ${{ matrix.rust }}
           cache-version: v0
           bundler-cache: true
-          cargo-cache: true
+          cargo-cache: ${{ matrix.repo.cargo-cache }}
           cargo-cache-clean: true
-          cargo-cache-strategy: ${{ matrix.repo.cargo-cache-strategy }}
       - name: Run unit tests
         env:
           SETUP_OUTPUTS: ${{ toJSON(steps.setup.outputs) }}

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -21,7 +21,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["2.7", "3.0", "3.1", "head"]
-        sccache: ["true", "false"]
+        cargo-cache: ["tarball", "sccache"]
         include:
           - os: "windows-latest"
             ruby: "mswin"
@@ -30,7 +30,7 @@ jobs:
               name: "oxidize-rb/oxi-test"
               ref: main
               run: bundle exec rake
-              sccache: "false"
+              cargo-cache: "sccache"
           - os: "windows-latest"
             ruby: "mswin"
             rust: "stable"
@@ -38,7 +38,7 @@ jobs:
               name: "matsadler/magnus"
               ref: main
               run: cargo test
-              sccache: "true"
+              cargo-cache: "sccache"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -64,7 +64,7 @@ jobs:
           bundler-cache: true
           cargo-cache: true
           cargo-cache-clean: true
-          sccache: ${{ matrix.repo.sccache }}
+          cargo-cache-strategy: ${{ matrix.repo.cargo-cache-strategy }}
       - name: Run unit tests
         env:
           SETUP_OUTPUTS: ${{ toJSON(steps.setup.outputs) }}

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -42,6 +42,16 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Log inputs
+        shell: bash
+        run: |
+          echo "OS: ${{ matrix.os }}"
+          echo "Ruby: ${{ matrix.ruby }}"
+          echo "Rust: ${{ matrix.rust }}"
+          echo "Repo: ${{ matrix.repo.name }}"
+          echo "Ref: ${{ matrix.repo.ref }}"
+          echo "Run: ${{ matrix.repo.run }}"
+          echo "sccache: ${{ matrix.repo.sccache }}"
       - uses: actions/checkout@v3
         with:
           repository: ${{ matrix.repo.name }}
@@ -58,6 +68,7 @@ jobs:
           bundler-cache: true
           cargo-cache: true
           cargo-cache-clean: true
+          sccache: ${{ matrix.repo.sccache }}
       - name: Run unit tests
         env:
           SETUP_OUTPUTS: ${{ toJSON(steps.setup.outputs) }}

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -23,26 +23,35 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["2.7", "3.0", "3.1", "head"]
-        cargo-cache: ["tarball", "sccache"]
+        cargo-cache: ["sccache"]
         include:
-          - os: "windows-latest"
-            ruby: "mswin"
+          - os: "ubuntu-latest"
+            ruby: "3.1"
             rust: "stable"
+            cargo-cache: "tarball"
             repo:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
               ref: main
               run: bundle exec rake
-              cargo-cache: "sccache"
+          - os: "windows-latest"
+            ruby: "mswin"
+            rust: "stable"
+            cargo-cache: "sccache"
+            repo:
+              name: "oxidize-rb/oxi-test"
+              slug: oxi-test
+              ref: main
+              run: bundle exec rake
           - os: "windows-latest"
             slug: magnus
             ruby: "mswin"
             rust: "stable"
+            cargo-cache: "sccache"
             repo:
               name: "matsadler/magnus"
               ref: main
               run: cargo test
-              cargo-cache: "sccache"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -66,7 +75,7 @@ jobs:
           rustup-toolchain: ${{ matrix.rust }}
           cache-version: v0
           bundler-cache: true
-          cargo-cache: ${{ matrix.repo.cargo-cache }}
+          cargo-cache: ${{ matrix.cargo-cache }}
           cargo-cache-clean: true
       - name: Run unit tests
         env:

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -21,6 +21,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["2.7", "3.0", "3.1", "head"]
+        sccache: ["true", "false"]
         include:
           - os: "windows-latest"
             ruby: "mswin"
@@ -29,6 +30,7 @@ jobs:
               name: "oxidize-rb/oxi-test"
               ref: main
               run: bundle exec rake
+              sccache: "false"
           - os: "windows-latest"
             ruby: "mswin"
             rust: "stable"
@@ -36,6 +38,7 @@ jobs:
               name: "matsadler/magnus"
               ref: main
               run: cargo test
+              sccache: "true"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -42,10 +42,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Log inputs
+      - name: Log matrix
         shell: bash
         env:
-          INPUTS: ${{ toJSON(inputs) }}
+          INPUTS: ${{ toJSON(matrix) }}
         run: |
           echo "$INPUTS" | jq
       - uses: actions/checkout@v3

--- a/post-run/readme.md
+++ b/post-run/readme.md
@@ -22,9 +22,10 @@ jobs:
 
 <!-- inputs -->
 
-| Name    | Description                     | Default                                   |
-| ------- | ------------------------------- | ----------------------------------------- |
-| **run** | A command that needs to be run. | `echo "This is a post-action command..."` |
+| Name    | Description                                                 | Default                                   |
+| ------- | ----------------------------------------------------------- | ----------------------------------------- |
+| **cwd** | A working directory from which the command needs to be run. |                                           |
+| **run** | A command that needs to be run.                             | `echo "This is a post-action command..."` |
 
 <!-- /inputs -->
 

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -189,24 +189,12 @@ runs:
           core.exportVariable('CARGO_INCREMENTAL', '0');
           core.exportVariable('SCCACHE_GHA_CACHE_FROM', '${{ steps.rust-toolchain.outputs.cachekey }}');
 
-    - name: Setup sccache keys
-      if: inputs.cargo-cache == 'sccache'
-      shell: bash
-      run: |
-        cache_level_1="${{ steps.rust-toolchain.outputs.cachekey }}__${{ steps.derive-toolchain.outputs.toolchain }}"
-        cache_level_2="${cache_level_1}__${{ hashFiles('**/Cargo.toml') }}"
-        cache_level_3="${cache_level_2}__${{ hashFiles('**/extconf.rb') }}"
-        cache_level_4="${cache_level_3}__${{ hashFiles('**/Cargo.lock') }}"
-
-        echo "SCCACHE_GHA_CACHE_TO=${cache_level_4}" >> $GITHUB_ENV
-        echo "SCCACHE_GHA_CACHE_FROM=$cache_level_4,$cache_level_3,$cache_level_2,$cache_level_1" >> $GITHUB_ENV
-
     - name: Install sccache
       if: inputs.cargo-cache == 'sccache'
       shell: bash
       run: |
         : Setup sccache
-        outpath="$HOME/.setup-ruby-and-rust/bin"
+        outpath="$(ruby -e 'puts File.join(ENV["HOME"], ".setup-ruby-and-rust", "bin")')"
         mkdir -p "$outpath"
         echo "$outpath" >> $GITHUB_PATH
 
@@ -218,6 +206,14 @@ runs:
           curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1
           popd
         fi
+
+        cache_level_1="${{ steps.rust-toolchain.outputs.cachekey }}__${{ steps.derive-toolchain.outputs.toolchain }}"
+        cache_level_2="${cache_level_1}__${{ hashFiles('**/Cargo.toml') }}"
+        cache_level_3="${cache_level_2}__${{ hashFiles('**/extconf.rb') }}"
+        cache_level_4="${cache_level_3}__${{ hashFiles('**/Cargo.lock') }}"
+
+        echo "SCCACHE_GHA_CACHE_TO=${cache_level_4}" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_CACHE_FROM=$cache_level_4,$cache_level_3,$cache_level_2,$cache_level_1" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -146,15 +146,22 @@ runs:
 
         echo "$HOME/.setup-ruby-and-rust/bin" >> $GITHUB_PATH
 
+    - name: Cargo registry cache
+      uses: actions/cache@v3
+      if: inputs.cargo-cache != 'false'
+      with:
+        key: cargo-registry
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+
     - name: Setup cargo cache
       uses: actions/cache@v3
       if: inputs.cargo-cache == 'tarball'
       with:
         path: |
           ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
           **/target/
           **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/
           ${{ inputs.cargo-cache-extra-path }}
@@ -192,10 +199,12 @@ runs:
         echo "$outpath" >> $GITHUB_PATH
 
         if [ ! -f "$outpath/sccache" ]; then
+          pushd "$outpath"
           version="v0.3.3"
           toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb --runner)"
           filename="sccache-$version-$toolchain.tar.gz"
-          curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1 -C "$outpath"
+          curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1
+          popd
         fi
 
     - name: Set LD_LIBRARY_PATH for Ruby

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -126,28 +126,7 @@ runs:
         echo "cache-key-level-4=$cache_level_4" >> $GITHUB_OUTPUT
         echo "cache-key=${cache_level_4}" >> $GITHUB_OUTPUT
 
-        # Since the cargo registry is a moving target, we generate cache keys
-        # based on some recent dates
-        cargo_registry_cache_keys=()
-        prefix="cr"
-
-        for i in {0..3}; do
-          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"H '+%Y%m%d%H')")")
-        done
-
-        for i in {0..10}; do
-          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"d '+%Y%m%d')")")
-        done
-
-        for i in {0..2}; do
-          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"m '+%Y%m')")")
-        done
-
-        # Use the first key as the root cache key
-        echo "cargo-registry-cache-key=${cargo_registry_cache_keys[0]}" >> $GITHUB_OUTPUT
-        cargo_registry_cache_keys="${cargo_registry_cache_keys[@]:1}"
-        cargo_registry_restore_keys_string="${cargo_registry_cache_keys[@]}"
-        echo "cargo-registry-restore-keys=${cargo_registry_restore_keys_string//$' '/%0A}" >> $GITHUB_OUTPUT
+        ruby --disable-gems $GITHUB_ACTION_PATH/helpers/cargo_registry_cache_keys.rb
 
     - name: Cache the "cargo-cache" executable
       uses: actions/cache@v3

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -195,9 +195,9 @@ runs:
         echo "$outpath" >> $GITHUB_PATH
 
         if [ ! -f "$outpath/sccache" ]; then
+          version="v0.3.3"
           toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb --runner)"
           filename="sccache-$version-$toolchain.tar.gz"
-          version="0.3.3"
           curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1 -C "$GITHUB_ACTION_PATH/bin"
         fi
 

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -185,9 +185,21 @@ runs:
           core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           core.exportVariable('RUSTC_WRAPPER', process.env.RUSTC_WRAPPER || 'sccache');
-          core.exportVariable('SCCACHE_C_CUSTOM_CACHE_BUSTER', '${{ inputs.cache-version }}');
+          core.exportVariable('SCCACHE_C_CUSTOM_CACHE_BUSTER', '${{ inputs.cache-version }}-${{ steps.rust-toolchain.outputs.cachekey }}');
           core.exportVariable('CARGO_INCREMENTAL', '0');
-          core.exportVariable('SCCACHE_GHA_CACHE_TO', '${{ steps.set-outputs.outputs.cache-key-level-1 }}');
+          core.exportVariable('SCCACHE_GHA_CACHE_FROM', '${{ steps.rust-toolchain.outputs.cachekey }}');
+
+    - name: Setup sccache keys
+      if: inputs.cargo-cache == 'sccache'
+      shell: bash
+      run: |
+        cache_level_1="${{ steps.rust-toolchain.outputs.cachekey }}__${{ steps.derive-toolchain.outputs.toolchain }}"
+        cache_level_2="${cache_level_1}__${{ hashFiles('**/Cargo.toml') }}"
+        cache_level_3="${cache_level_2}__${{ hashFiles('**/extconf.rb') }}"
+        cache_level_4="${cache_level_3}__${{ hashFiles('**/Cargo.lock') }}"
+
+        echo "SCCACHE_GHA_CACHE_TO=${cache_level_4}" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_CACHE_FROM=$cache_level_4,$cache_level_3,$cache_level_2,$cache_level_1" >> $GITHUB_ENV
 
     - name: Install sccache
       if: inputs.cargo-cache == 'sccache'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -128,16 +128,23 @@ runs:
 
         ruby --disable-gems $GITHUB_ACTION_PATH/helpers/cargo_registry_cache_keys.rb
 
+        if [ "${{ inputs.cargo-cache }}" = "true" ]; then
+          echo "::warning::cargo-cache now defaults to 'sccache' instead of 'tarball'. Please update your workflow to use 'sccache' instead of 'true'. If you experience issues with 'sccache', you can use 'tarball' instead (but please report this upstream)."
+          echo "cargo-cache=sccache" >> $GITHUB_OUTPUT
+        else
+          echo "cargo-cache=${{ inputs.cargo-cache }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Cache the "cargo-cache" executable
       uses: actions/cache@v3
-      if: inputs.cargo-cache-clean == 'true' && inputs.cargo-cache == 'tarball'
+      if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
         path: ~/.setup-ruby-and-rust/bin/cargo-cache
         key: ${{ steps.set-outputs.outputs.ruby-platform }}-cargo-cache-clean-0.8.3
 
     - name: Install cargo-cache
       id: install-cargo-cache
-      if: inputs.cargo-cache-clean == 'true' && inputs.cargo-cache == 'tarball'
+      if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
       shell: bash
       run: |
         : Setup cargo-cache
@@ -149,7 +156,7 @@ runs:
 
     - name: Cargo registry cache
       uses: actions/cache@v3
-      if: inputs.cargo-cache != 'false'
+      if: steps.set-outputs.outputs.cargo-cache != 'false'
       with:
         key: ${{ steps.set-outputs.outputs.cargo-registry-cache-key }}
         restore-keys: |
@@ -161,7 +168,7 @@ runs:
 
     - name: Setup cargo cache
       uses: actions/cache@v3
-      if: inputs.cargo-cache == 'tarball'
+      if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
         path: |
           ~/.cargo/bin/
@@ -174,14 +181,14 @@ runs:
           ${{ steps.set-outputs.outputs.cache-key-level-2 }}
 
     - name: Clean the cargo cache
-      if: inputs.cargo-cache-clean == 'true' && inputs.cargo-cache == 'tarball'
+      if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
       uses: oxidize-rb/actions/post-run@main
       with:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
 
     - name: Configure sccache
-      if: inputs.cargo-cache == 'sccache' || inputs.cargo-cache == 'true'
+      if: steps.set-outputs.outputs.cargo-cache == 'sccache'
       uses: actions/github-script@v6
       with:
         script: |
@@ -193,7 +200,7 @@ runs:
           core.exportVariable('SCCACHE_GHA_CACHE_FROM', '${{ steps.rust-toolchain.outputs.cachekey }}');
 
     - name: Install sccache
-      if: inputs.cargo-cache == 'sccache' || inputs.cargo-cache == 'true'
+      if: steps.set-outputs.outputs.cargo-cache == 'sccache'
       shell: bash
       run: |
         : Setup sccache

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -36,10 +36,7 @@ inputs:
       Comma-separated string of additional components to install e.g. clippy, rustfmt
     default: clippy, rustfmt
   cargo-cache:
-    description: "Automatically cache the target dir and Cargo registry index"
-    default: "false"
-  sccache:
-    description: "Use sccache for faster compilation"
+    description: "Strategy to use for caching build artifacts (either 'sccache', 'tarball', or 'false')"
     default: "false"
   cargo-cache-clean:
     description: "Clean the cargo cache with cargo cache --autoclean"
@@ -132,14 +129,14 @@ runs:
 
     - name: Cache the "cargo-cache" executable
       uses: actions/cache@v3
-      if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
+      if: inputs.cargo-cache-clean == 'true' && inputs.cargo-cache == 'tarball'
       with:
         path: ~/.setup-ruby-and-rust/bin/cargo-cache
         key: ${{ steps.set-outputs.outputs.ruby-platform }}-cargo-cache-clean-0.8.3
 
     - name: Install cargo-cache
       id: install-cargo-cache
-      if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
+      if: inputs.cargo-cache-clean == 'true' && inputs.cargo-cache == 'tarball'
       shell: bash
       run: |
         : Setup cargo-cache
@@ -151,7 +148,7 @@ runs:
 
     - name: Setup cargo cache
       uses: actions/cache@v3
-      if: inputs.cargo-cache == 'true' && inputs.sccache == 'false'
+      if: inputs.cargo-cache == 'tarball'
       with:
         path: |
           ~/.cargo/bin/
@@ -167,14 +164,14 @@ runs:
           ${{ steps.set-outputs.outputs.cache-key-level-2 }}
 
     - name: Clean the cargo cache
-      if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
-      uses: oxidize-rb/actions/post-run@main # TODO: update
+      if: inputs.cargo-cache-clean == 'true' && inputs.cargo-cache == 'tarball'
+      uses: oxidize-rb/actions/post-run@main
       with:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
 
     - name: Configure sccache
-      if: inputs.cargo-cache == 'true' || inputs.sccache == 'true'
+      if: inputs.cargo-cache == 'sccache'
       uses: actions/github-script@v6
       with:
         script: |
@@ -186,7 +183,7 @@ runs:
           core.exportVariable('SCCACHE_GHA_CACHE_TO', '${{ steps.set-outputs.outputs.cache-key-level-1 }}');
 
     - name: Install sccache
-      if: inputs.cargo-cache == 'true' || inputs.sccache == 'true'
+      if: inputs.cargo-cache == 'sccache'
       shell: bash
       run: |
         : Setup sccache
@@ -198,7 +195,7 @@ runs:
           version="v0.3.3"
           toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb --runner)"
           filename="sccache-$version-$toolchain.tar.gz"
-          curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1 -C "$GITHUB_ACTION_PATH/bin"
+          curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1 -C "$outpath"
         fi
 
     - name: Set LD_LIBRARY_PATH for Ruby

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -151,7 +151,7 @@ runs:
       uses: actions/cache@v3
       if: inputs.cargo-cache != 'false'
       with:
-        key: ${{ steps.set-outputs.outputs.cache-key }}
+        key: ${{ steps.set-outputs.outputs.cargo-registry-cache-key }}
         restore-keys: |
           ${{ steps.set-outputs.outputs.cargo-registry-restore-keys }}
         path: |

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -235,10 +235,10 @@ runs:
         echo "Ruby libdir is $libdir"
 
         if [ ! -z "$LD_LIBRARY_PATH" ]; then
-          echo "Appending to LD_LIBRARY_PATH"
+          echo "::info::Appending to LD_LIBRARY_PATH"
           echo "LD_LIBRARY_PATH=$libdir:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         else
-          echo "Setting new LD_LIBRARY_PATH"
+          echo "::info::Setting new LD_LIBRARY_PATH"
           echo "LD_LIBRARY_PATH=$libdir" >> $GITHUB_ENV
         fi
         echo "::endgroup::"
@@ -261,7 +261,7 @@ runs:
         echo "::group::Configuring environment"
 
         if [ "${{ inputs.debug }}" = "true" ]; then
-          echo "Setting debug mode"
+          echo "::info::Setting debug mode"
           echo "RB_SYS_DEBUG_BUILD=1" >> $GITHUB_ENV
           echo "SCCACHE_LOG=debug" >> $GITHUB_ENV
         fi

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -195,7 +195,7 @@ runs:
         echo "$outpath" >> $GITHUB_PATH
 
         if [ ! -f "$outpath/sccache" ]; then
-          toolchain="$(derive_toolchain.rb --runner)"
+          toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb --runner)"
           filename="sccache-$version-$toolchain.tar.gz"
           version="0.3.3"
           curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1 -C "$GITHUB_ACTION_PATH/bin"

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -124,8 +124,25 @@ runs:
         echo "cache-key-level-2=$cache_level_2" >> $GITHUB_OUTPUT
         echo "cache-key-level-3=$cache_level_3" >> $GITHUB_OUTPUT
         echo "cache-key-level-4=$cache_level_4" >> $GITHUB_OUTPUT
-
         echo "cache-key=${cache_level_4}" >> $GITHUB_OUTPUT
+
+        # Since the cargo registry is a moving target, we generate cache keys
+        # based on some recent dates
+        cargo_registry_cache_keys=()
+        prefix="cargo-registry__"
+
+        for i in {0..12}; do
+          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"H '+%Y-%m-%d-%H')")")
+          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"d '+%Y-%m-%d')")")
+          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"m '+%Y-%m')")")
+        done
+
+        # Use the first key as the root cache key
+        echo "cargo-registry-cache-key=${cargo_registry_cache_keys[0]}" >> $GITHUB_OUTPUT
+        cargo_registry_cache_keys="${cargo_registry_cache_keys[@]:1}"
+        cargo_registry_restore_keys_string="${cargo_registry_cache_keys[@]}"
+        echo "cargo-registry-restore-keys=${cargo_registry_restore_keys_string//$' '/%0A}" >> $GITHUB_OUTPUT
+
 
     - name: Cache the "cargo-cache" executable
       uses: actions/cache@v3
@@ -150,7 +167,9 @@ runs:
       uses: actions/cache@v3
       if: inputs.cargo-cache != 'false'
       with:
-        key: cargo-registry
+        key: ${{ steps.set-outputs.outputs.cache-key }}
+        restore-keys: |
+          ${{ steps.set-outputs.outputs.cargo-registry-restore-keys }}
         path: |
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -178,7 +178,7 @@ runs:
         cwd: ${{ inputs.working-directory }}
 
     - name: Configure sccache
-      if: inputs.cargo-cache == 'sccache'
+      if: inputs.cargo-cache == 'sccache' || inputs.cargo-cache == 'true'
       uses: actions/github-script@v6
       with:
         script: |
@@ -190,7 +190,7 @@ runs:
           core.exportVariable('SCCACHE_GHA_CACHE_FROM', '${{ steps.rust-toolchain.outputs.cachekey }}');
 
     - name: Install sccache
-      if: inputs.cargo-cache == 'sccache'
+      if: inputs.cargo-cache == 'sccache' || inputs.cargo-cache == 'true'
       shell: bash
       run: |
         : Setup sccache

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -38,6 +38,9 @@ inputs:
   cargo-cache:
     description: "Automatically cache the target dir and Cargo registry index"
     default: "false"
+  sccache:
+    description: "Use sccache for faster compilation"
+    default: "false"
   cargo-cache-clean:
     description: "Clean the cargo cache with cargo cache --autoclean"
     default: "false"
@@ -129,14 +132,14 @@ runs:
 
     - name: Cache the "cargo-cache" executable
       uses: actions/cache@v3
-      if: inputs.cargo-cache-clean == 'true'
+      if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
       with:
         path: ~/.setup-ruby-and-rust/bin/cargo-cache
         key: ${{ steps.set-outputs.outputs.ruby-platform }}-cargo-cache-clean-0.8.3
 
     - name: Install cargo-cache
       id: install-cargo-cache
-      if: inputs.cargo-cache-clean == 'true'
+      if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
       shell: bash
       run: |
         : Setup cargo-cache
@@ -148,7 +151,7 @@ runs:
 
     - name: Setup cargo cache
       uses: actions/cache@v3
-      if: inputs.cargo-cache == 'true'
+      if: inputs.cargo-cache == 'true' && inputs.sccache == 'false'
       with:
         path: |
           ~/.cargo/bin/
@@ -164,11 +167,39 @@ runs:
           ${{ steps.set-outputs.outputs.cache-key-level-2 }}
 
     - name: Clean the cargo cache
-      if: inputs.cargo-cache-clean == 'true'
+      if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
       uses: oxidize-rb/actions/post-run@autoclean # TODO: update
       with:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
+
+    - name: Configure sccache
+      if: inputs.cargo-cache == 'true' && inputs.sccache == 'true'
+      uses: actions/github-script@v6
+      with:
+        script: |
+          core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+          core.exportVariable('RUSTC_WRAPPER', process.env.RUSTC_WRAPPER || 'sccache');
+          core.exportVariable('SCCACHE_C_CUSTOM_CACHE_BUSTER', '${{ inputs.cache-version }}');
+          core.exportVariable('CARGO_INCREMENTAL', '0');
+          core.exportVariable('SCCACHE_GHA_CACHE_TO', '${{ steps.set-outputs.outputs.cache-key-level-1 }}');
+
+    - name: Install sccache
+      if: inputs.cargo-cache == 'true' && inputs.sccache == 'true'
+      shell: bash
+      run: |
+        : Setup sccache
+        outpath="$HOME/.setup-ruby-and-rust/bin"
+        mkdir -p "$outpath"
+        echo "$outpath" >> $GITHUB_PATH
+
+        if [ ! -f "$outpath/sccache" ]; then
+          toolchain="$(derive_toolchain.rb --runner)"
+          filename="sccache-$version-$toolchain.tar.gz"
+          version="0.3.3"
+          curl -L "https://github.com/mozilla/sccache/releases/download/$version/$filename" | tar -xz --strip-components=1 -C "$GITHUB_ACTION_PATH/bin"
+        fi
 
     - name: Set LD_LIBRARY_PATH for Ruby
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'
@@ -208,6 +239,7 @@ runs:
         if [ "${{ inputs.debug }}" = "true" ]; then
           echo "Setting debug mode"
           echo "RB_SYS_DEBUG_BUILD=1" >> $GITHUB_ENV
+          echo "SCCACHE_LOG=debug" >> $GITHUB_ENV
         fi
 
         if [ "${{ inputs.prefer-ruby-static }}" = "true" ]; then

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -129,12 +129,18 @@ runs:
         # Since the cargo registry is a moving target, we generate cache keys
         # based on some recent dates
         cargo_registry_cache_keys=()
-        prefix="cargo-registry__"
+        prefix="cr"
 
-        for i in {0..12}; do
-          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"H '+%Y-%m-%d-%H')")")
-          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"d '+%Y-%m-%d')")")
-          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"m '+%Y-%m')")")
+        for i in {0..3}; do
+          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"H '+%Y%m%d%H')")")
+        done
+
+        for i in {0..10}; do
+          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"d '+%Y%m%d')")")
+        done
+
+        for i in {0..2}; do
+          cargo_registry_cache_keys+=("$(echo "$prefix$(date -v -"$i"m '+%Y%m')")")
         done
 
         # Use the first key as the root cache key
@@ -142,7 +148,6 @@ runs:
         cargo_registry_cache_keys="${cargo_registry_cache_keys[@]:1}"
         cargo_registry_restore_keys_string="${cargo_registry_cache_keys[@]}"
         echo "cargo-registry-restore-keys=${cargo_registry_restore_keys_string//$' '/%0A}" >> $GITHUB_OUTPUT
-
 
     - name: Cache the "cargo-cache" executable
       uses: actions/cache@v3

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -168,13 +168,13 @@ runs:
 
     - name: Clean the cargo cache
       if: inputs.cargo-cache-clean == 'true' && inputs.sccache == 'false'
-      uses: oxidize-rb/actions/post-run@autoclean # TODO: update
+      uses: oxidize-rb/actions/post-run@main # TODO: update
       with:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
 
     - name: Configure sccache
-      if: inputs.cargo-cache == 'true' && inputs.sccache == 'true'
+      if: inputs.cargo-cache == 'true' || inputs.sccache == 'true'
       uses: actions/github-script@v6
       with:
         script: |
@@ -186,7 +186,7 @@ runs:
           core.exportVariable('SCCACHE_GHA_CACHE_TO', '${{ steps.set-outputs.outputs.cache-key-level-1 }}');
 
     - name: Install sccache
-      if: inputs.cargo-cache == 'true' && inputs.sccache == 'true'
+      if: inputs.cargo-cache == 'true' || inputs.sccache == 'true'
       shell: bash
       run: |
         : Setup sccache

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -37,7 +37,7 @@ inputs:
     default: clippy, rustfmt
   cargo-cache:
     description: "Strategy to use for caching build artifacts (either 'sccache', 'tarball', or 'false')"
-    default: "false"
+    default: "default"
   cargo-cache-clean:
     description: "Clean the cargo cache with cargo cache --autoclean"
     default: "false"
@@ -130,6 +130,9 @@ runs:
 
         if [ "${{ inputs.cargo-cache }}" = "true" ]; then
           echo "::warning::cargo-cache now defaults to 'sccache' instead of 'tarball'. Please update your workflow to use 'sccache' instead of 'true'. If you experience issues with 'sccache', you can use 'tarball' instead (but please report this upstream)."
+          echo "cargo-cache=sccache" >> $GITHUB_OUTPUT
+        elif [ "${{ inputs.cargo-cache }}" = "default" ]; then
+          echo "::warning::cargo-cache now defaults to 'sccache' when no argument is provided. If you would like to disable caching, please explicitly set cargo-cache: 'false'."
           echo "cargo-cache=sccache" >> $GITHUB_OUTPUT
         else
           echo "cargo-cache=${{ inputs.cargo-cache }}" >> $GITHUB_OUTPUT

--- a/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
+++ b/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
@@ -1,0 +1,25 @@
+# This script generates cache keys for the cargo registry cache. Since the cargo
+# registry is a moving target, we generate cache keys based on some recent dates.
+
+cargo_registry_cache_keys = []
+prefix = "cr"
+
+(0..12).each do |i|
+  cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60)).strftime("%Y%m%d%H")}"
+end
+
+(0..21).each do |i|
+  cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60 * 24)).strftime("%Y%m%d")}"
+end
+
+(0..3).each do |i|
+  cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60 * 24 * 30)).strftime("%Y%m")}"
+end
+
+cache_key = cargo_registry_cache_keys[0]
+restore_keys = cargo_registry_cache_keys[1..-1].join("%0A")
+
+File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
+  f.puts "cargo-registry-cache-key=\"#{cache_key}\""
+  f.puts "cargo-registry-restore-keys=\"#{restore_keys}\""
+end

--- a/setup-ruby-and-rust/helpers/derive_toolchain.rb
+++ b/setup-ruby-and-rust/helpers/derive_toolchain.rb
@@ -13,4 +13,16 @@ def derive_rust_toolchain_from_rbconfig(input_rust_toolchain)
   end
 end
 
-puts derive_rust_toolchain_from_rbconfig(ARGV.first)
+if ARGV.include?("--runner")
+  case RbConfig::CONFIG["host_os"]
+  when /mingw|mswin/
+    puts "x86_64-pc-windows-msvc"
+  when /darwin/
+    puts "x86_64-apple-darwin"
+  when /linux/
+    puts "x86_64-unknown-linux-musl"
+  end
+else
+  puts derive_rust_toolchain_from_rbconfig(ARGV.first)
+end
+

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -49,7 +49,7 @@ jobs:
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | **bundler-cache**          | Run "bundle install", and cache the result automatically. Either true or false.                                                                             | `false`           |
 | **cache-version**          | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache.                            | `v0`              |
-| **cargo-cache**            | Strategy to use for caching build artifacts (either 'sccache', 'tarball', or 'false')                                                                       | `false`           |
+| **cargo-cache**            | Strategy to use for caching build artifacts (either 'sccache', 'tarball', or 'false')                                                                       | `default`         |
 | **cargo-cache-clean**      | Clean the cargo cache with cargo cache --autoclean                                                                                                          | `false`           |
 | **cargo-cache-extra-path** | Paths to cache for cargo and gem compilation                                                                                                                |                   |
 | **cargo-vendor**           | Vendor cargo dependencies to avoid repeated downloads                                                                                                       | `false`           |

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -49,7 +49,7 @@ jobs:
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | **bundler-cache**          | Run "bundle install", and cache the result automatically. Either true or false.                                                                             | `false`           |
 | **cache-version**          | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache.                            | `v0`              |
-| **cargo-cache**            | Automatically cache the target dir and Cargo registry index                                                                                                 | `false`           |
+| **cargo-cache**            | Strategy to use for caching build artifacts (either 'sccache', 'tarball', or 'false')                                                                       | `false`           |
 | **cargo-cache-clean**      | Clean the cargo cache with cargo cache --autoclean                                                                                                          | `false`           |
 | **cargo-cache-extra-path** | Paths to cache for cargo and gem compilation                                                                                                                |                   |
 | **cargo-vendor**           | Vendor cargo dependencies to avoid repeated downloads                                                                                                       | `false`           |
@@ -60,7 +60,6 @@ jobs:
 | **rustup-components**      | Comma-separated string of additional components to install e.g. clippy, rustfmt                                                                             | `clippy, rustfmt` |
 | **rustup-targets**         | Comma-separated string of additional targets to install e.g. wasm32-unknown-unknown                                                                         |                   |
 | **rustup-toolchain**       | Rustup toolchain specifier e.g. stable, nightly, 1.42.0, nightly-2022-01-01.                                                                                | `stable`          |
-| **sccache**                | Use sccache for faster compilation                                                                                                                          | `false`           |
 | **working-directory**      | The working directory to use for resolving paths for .ruby-version, .tool-versions and Gemfile.lock.                                                        |                   |
 
 <!-- /inputs -->

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -45,22 +45,23 @@ jobs:
 
 <!-- inputs -->
 
-| Name                       | Description                                                                                                                      | Default           |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| **bundler-cache**          | Run "bundle install", and cache the result automatically. Either true or false.                                                  | `false`           |
-| **cache-version**          | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache. | `v0`              |
-| **cargo-cache**            | Automatically cache the target dir and Cargo registry index                                                                      | `false`           |
-| **cargo-cache-clean**      | Clean the cargo cache with cargo cache --autoclean                                                                               | `false`           |
-| **cargo-cache-extra-path** | Paths to cache for cargo and gem compilation                                                                                     |                   |
-| **cargo-vendor**           | Vendor cargo dependencies to avoid repeated downloads                                                                            | `false`           |
-| **debug**                  | Enable verbose debugging info (includes summary of action)                                                                       | `false`           |
-| **prefer-ruby-static**     | Prefer using libruby static if it's available                                                                                    | `false`           |
-| **ruby-version**           | Engine and version to use, see the syntax in the README. Reads from .ruby-version or .tool-versions if unset.                    | `default`         |
-| **rubygems**               | Runs `gem update --system`. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info.                          | `default`         |
-| **rustup-components**      | Comma-separated string of additional components to install e.g. clippy, rustfmt                                                  | `clippy, rustfmt` |
-| **rustup-targets**         | Comma-separated string of additional targets to install e.g. wasm32-unknown-unknown                                              |                   |
-| **rustup-toolchain**       | Rustup toolchain specifier e.g. stable, nightly, 1.42.0, nightly-2022-01-01.                                                     | `stable`          |
-| **working-directory**      | The working directory to use for resolving paths for .ruby-version, .tool-versions and Gemfile.lock.                             |                   |
+| Name                       | Description                                                                                                                                                 | Default           |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| **bundler-cache**          | Run "bundle install", and cache the result automatically. Either true or false.                                                                             | `false`           |
+| **cache-version**          | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache.                            | `v0`              |
+| **cargo-cache**            | Automatically cache the target dir and Cargo registry index                                                                                                 | `false`           |
+| **cargo-cache-clean**      | Clean the cargo cache with cargo cache --autoclean                                                                                                          | `false`           |
+| **cargo-cache-extra-path** | Paths to cache for cargo and gem compilation                                                                                                                |                   |
+| **cargo-vendor**           | Vendor cargo dependencies to avoid repeated downloads                                                                                                       | `false`           |
+| **debug**                  | Enable verbose debugging info (includes summary of action)                                                                                                  | `false`           |
+| **prefer-ruby-static**     | Prefer using libruby static if it's available                                                                                                               | `false`           |
+| **ruby-version**           | Engine and version to use, see the syntax in the README. Reads from .ruby-version or .tool-versions if unset. Can be set to 'none' to skip installing Ruby. | `default`         |
+| **rubygems**               | Runs `gem update --system`. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info.                                                     | `default`         |
+| **rustup-components**      | Comma-separated string of additional components to install e.g. clippy, rustfmt                                                                             | `clippy, rustfmt` |
+| **rustup-targets**         | Comma-separated string of additional targets to install e.g. wasm32-unknown-unknown                                                                         |                   |
+| **rustup-toolchain**       | Rustup toolchain specifier e.g. stable, nightly, 1.42.0, nightly-2022-01-01.                                                                                | `stable`          |
+| **sccache**                | Use sccache for faster compilation                                                                                                                          | `false`           |
+| **working-directory**      | The working directory to use for resolving paths for .ruby-version, .tool-versions and Gemfile.lock.                                                        |                   |
 
 <!-- /inputs -->
 


### PR DESCRIPTION
As of recent, [sscache now has a GHA backend](https://github.com/mozilla/sccache#github-actions) for caching crate compilation. After testing it out, I've found it to more efficient that that previous strategy of uploading a massive tarball.

One of the main benefits is that the performance is much more predictable since caching is done in much smaller compilation units.

This PR enables it by default instead of the tarball upload strategy. If you experience issues with this, you can use the old strategy with `cargo-cache: tarball` in your action config.