### PR TITLE
Revert back to `tarball` strategy for caching, with enhancements

### DIFF
--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -30,7 +30,7 @@ jobs:
           - os: "ubuntu-latest"
             ruby: "3.1"
             rust: "stable"
-            cargo-cache: "tarball"
+            cargo-cache: "sccache"
             repo:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -132,11 +132,9 @@ runs:
         ruby --disable-gems $GITHUB_ACTION_PATH/helpers/cargo_registry_cache_keys.rb
 
         if [ "${{ inputs.cargo-cache }}" = "true" ]; then
-          echo "::warning::cargo-cache now defaults to 'sccache' instead of 'tarball'. Please update your workflow to use 'sccache' instead of 'true'. If you experience issues with 'sccache', you can use 'tarball' instead (but please report this upstream)."
-          echo "cargo-cache=sccache" >> $GITHUB_OUTPUT
+          echo "cargo-cache=tarball" >> $GITHUB_OUTPUT
         elif [ "${{ inputs.cargo-cache }}" = "default" ]; then
-          echo "::warning::cargo-cache now defaults to 'sccache' when no argument is provided. If you would like to disable caching, please explicitly set cargo-cache: 'false'."
-          echo "cargo-cache=sccache" >> $GITHUB_OUTPUT
+          echo "cargo-cache=tarball" >> $GITHUB_OUTPUT
         else
           echo "cargo-cache=${{ inputs.cargo-cache }}" >> $GITHUB_OUTPUT
         fi

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -40,7 +40,7 @@ inputs:
     default: "default"
   cargo-cache-clean:
     description: "Clean the cargo cache with cargo cache --autoclean"
-    default: "false"
+    default: "true"
   cargo-cache-extra-path:
     description: "Paths to cache for cargo and gem compilation"
   cargo-vendor:
@@ -188,7 +188,7 @@ runs:
       with:
         key: ${{ steps.set-outputs.outputs.ext-cachel-level-3 }}
         path: |
-          **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/
+          **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/target/
           ${{ inputs.cargo-cache-extra-path }}
         restore-keys: |
           ${{ steps.set-outputs.outputs.ext-cache-key-level-2 }}

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -128,6 +128,7 @@ runs:
         echo "ext-cache-key-level-1=$ext_cache_level_1" >> $GITHUB_OUTPUT
         echo "ext-cache-key-level-2=$ext_cache_level_2" >> $GITHUB_OUTPUT
         echo "ext-cache-key-level-3=$ext_cache_level_3" >> $GITHUB_OUTPUT
+        echo "cache-key=$ext_cache_level_3" >> $GITHUB_OUTPUT
 
         ruby --disable-gems $GITHUB_ACTION_PATH/helpers/cargo_registry_cache_keys.rb
 

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -186,7 +186,7 @@ runs:
       uses: actions/cache@v3
       if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
-        key: ${{ steps.set-outputs.outputs.ext-cachel-level-3 }}
+        key: ${{ steps.set-outputs.outputs.ext-cache-key-level-3 }}
         path: |
           **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/target/
           ${{ inputs.cargo-cache-extra-path }}

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -115,16 +115,19 @@ runs:
         echo "ruby-prefix=$(rbconfig prefix)" >> $GITHUB_OUTPUT
         echo "ruby-platform=$ruby_platform" >> $GITHUB_OUTPUT
 
-        cache_level_1="${{ inputs.cache-version }}__$(rbconfig ruby_version)__${ruby_platform}__${{ steps.rust-toolchain.outputs.cachekey }}"
-        cache_level_2="${cache_level_1}__${{ hashFiles('**/extconf.rb') }}"
-        cache_level_3="${cache_level_2}__${{ hashFiles('**/Cargo.toml', '**/Gemfile') }}"
-        cache_level_4="${cache_level_3}__${{ hashFiles('**/Cargo.lock', '**/Gemfile.lock') }}"
+        base_cache_level_1="${{ inputs.cache-version }}__${{ steps.rust-toolchain.outputs.cachekey }}__${ruby_platform}"
+        base_cache_level_2="${base_cache_level_1}__${{ hashFiles('**/Cargo.toml') }}"
+        base_cache_level_3="${base_cache_level_2}__${{ hashFiles('**/Cargo.lock') }}"
+        echo "base-cache-key-level-1=$base_cache_level_1" >> $GITHUB_OUTPUT
+        echo "base-cache-key-level-2=$base_cache_level_2" >> $GITHUB_OUTPUT
+        echo "base-cache-key-level-3=$base_cache_level_3" >> $GITHUB_OUTPUT
 
-        echo "cache-key-level-1=$cache_level_1" >> $GITHUB_OUTPUT
-        echo "cache-key-level-2=$cache_level_2" >> $GITHUB_OUTPUT
-        echo "cache-key-level-3=$cache_level_3" >> $GITHUB_OUTPUT
-        echo "cache-key-level-4=$cache_level_4" >> $GITHUB_OUTPUT
-        echo "cache-key=${cache_level_4}" >> $GITHUB_OUTPUT
+        ext_cache_level_1="${base_cache_level_1}__${{ hashFiles('**/extconf.rb') }}"``
+        ext_cache_level_2="${ext_cache_level_2}__${{ hashFiles('**/Gemfile') }}"``
+        ext_cache_level_3="${ext_cache_level_3}__${{ hashFiles('**/Gemfile.lock') }}"``
+        echo "ext-cache-key-level-1=$ext_cache_level_1" >> $GITHUB_OUTPUT
+        echo "ext-cache-key-level-2=$ext_cache_level_2" >> $GITHUB_OUTPUT
+        echo "ext-cache-key-level-3=$ext_cache_level_3" >> $GITHUB_OUTPUT
 
         ruby --disable-gems $GITHUB_ACTION_PATH/helpers/cargo_registry_cache_keys.rb
 
@@ -169,19 +172,29 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
 
-    - name: Setup cargo cache
+    - name: Setup base cargo cache
       uses: actions/cache@v3
       if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
         path: |
           ~/.cargo/bin/
-          **/target/
+          target/
+        key: ${{ steps.set-outputs.outputs.base-cachel-level-3 }}
+        restore-keys: |
+          ${{ steps.set-outputs.outputs.base-cachel-level-2 }}
+          ${{ steps.set-outputs.outputs.base-cachel-level-1 }}
+
+    - name: Setup ext cargo cache
+      uses: actions/cache@v3
+      if: steps.set-outputs.outputs.cargo-cache == 'tarball'
+      with:
+        path: |
           **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/
           ${{ inputs.cargo-cache-extra-path }}
-        key: ${{ steps.set-outputs.outputs.cache-key }}
+        key: ${{ steps.set-outputs.outputs.ext-cachel-level-3 }}
         restore-keys: |
-          ${{ steps.set-outputs.outputs.cache-key-level-3 }}
-          ${{ steps.set-outputs.outputs.cache-key-level-2 }}
+          ${{ steps.set-outputs.outputs.ext-cachel-level-2 }}
+          ${{ steps.set-outputs.outputs.ext-cachel-level-1 }}
 
     - name: Clean the cargo cache
       if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
@@ -199,7 +212,6 @@ runs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           core.exportVariable('RUSTC_WRAPPER', process.env.RUSTC_WRAPPER || 'sccache');
           core.exportVariable('SCCACHE_C_CUSTOM_CACHE_BUSTER', '${{ inputs.cache-version }}-${{ steps.rust-toolchain.outputs.cachekey }}');
-          core.exportVariable('CARGO_INCREMENTAL', '0');
           core.exportVariable('SCCACHE_GHA_CACHE_FROM', '${{ steps.rust-toolchain.outputs.cachekey }}');
 
     - name: Install sccache
@@ -263,11 +275,14 @@ runs:
         : Configure environment
         echo "::group::Configuring environment"
 
+        echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+
         if [ "${{ inputs.debug }}" = "true" ]; then
           echo "::info::Setting debug mode"
           echo "RB_SYS_DEBUG_BUILD=1" >> $GITHUB_ENV
           echo "SCCACHE_LOG=debug" >> $GITHUB_ENV
         fi
+
 
         if [ "${{ inputs.prefer-ruby-static }}" = "true" ]; then
           echo "::group::Attempting to configure static libruby"

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -210,18 +210,17 @@ runs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           core.exportVariable('RUSTC_WRAPPER', process.env.RUSTC_WRAPPER || 'sccache');
           core.exportVariable('SCCACHE_C_CUSTOM_CACHE_BUSTER', '${{ inputs.cache-version }}-${{ steps.rust-toolchain.outputs.cachekey }}');
-          core.exportVariable('SCCACHE_GHA_CACHE_FROM', '${{ steps.rust-toolchain.outputs.cachekey }}');
 
     - name: Install sccache
       if: steps.set-outputs.outputs.cargo-cache == 'sccache'
       shell: bash
       run: |
         : Setup sccache
-        outpath="$(ruby -e 'puts File.join(ENV["HOME"], ".setup-ruby-and-rust", "bin")')"
-        mkdir -p "$outpath"
-        echo "$outpath" >> $GITHUB_PATH
 
-        if [ ! -f "$outpath/sccache" ]; then
+        if ! command -v sccache &> /dev/null; then
+          outpath="$(ruby -e 'puts File.join(ENV["HOME"], ".setup-ruby-and-rust", "bin")')"
+          mkdir -p "$outpath"
+          echo "$outpath" >> $GITHUB_PATH
           pushd "$outpath"
           version="v0.3.3"
           toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb --runner)"
@@ -230,13 +229,11 @@ runs:
           popd
         fi
 
-        cache_level_1="${{ steps.rust-toolchain.outputs.cachekey }}__${{ steps.derive-toolchain.outputs.toolchain }}"
-        cache_level_2="${cache_level_1}__${{ hashFiles('**/Cargo.toml') }}"
-        cache_level_3="${cache_level_2}__${{ hashFiles('**/extconf.rb') }}"
-        cache_level_4="${cache_level_3}__${{ hashFiles('**/Cargo.lock') }}"
+        cache_from="${{ steps.rust-toolchain.outputs.cachekey }}__${{ steps.derive-toolchain.outputs.toolchain }}"
+        cache_to="${cache_from}__${GITHUB_SHA}"
 
-        echo "SCCACHE_GHA_CACHE_TO=${cache_level_4}" >> $GITHUB_ENV
-        echo "SCCACHE_GHA_CACHE_FROM=$cache_level_4,$cache_level_3,$cache_level_2,$cache_level_1" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_CACHE_FROM=$cache_from" >> $GITHUB_ENV
+        echo "SCCACHE_GHA_CACHE_TO=$cache_to" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -174,25 +174,25 @@ runs:
       uses: actions/cache@v3
       if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
+        key: ${{ steps.set-outputs.outputs.base-cachel-level-3 }}
         path: |
           ~/.cargo/bin/
-          target/
-        key: ${{ steps.set-outputs.outputs.base-cachel-level-3 }}
+          ./target/
         restore-keys: |
-          ${{ steps.set-outputs.outputs.base-cachel-level-2 }}
-          ${{ steps.set-outputs.outputs.base-cachel-level-1 }}
+          ${{ steps.set-outputs.outputs.base-cache-key-level-2 }}
+          ${{ steps.set-outputs.outputs.base-cache-key-level-1 }}
 
     - name: Setup ext cargo cache
       uses: actions/cache@v3
       if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
+        key: ${{ steps.set-outputs.outputs.ext-cachel-level-3 }}
         path: |
           **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/
           ${{ inputs.cargo-cache-extra-path }}
-        key: ${{ steps.set-outputs.outputs.ext-cachel-level-3 }}
         restore-keys: |
-          ${{ steps.set-outputs.outputs.ext-cachel-level-2 }}
-          ${{ steps.set-outputs.outputs.ext-cachel-level-1 }}
+          ${{ steps.set-outputs.outputs.ext-cache-key-level-2 }}
+          ${{ steps.set-outputs.outputs.ext-cache-key-level-1 }}
 
     - name: Clean the cargo cache
       if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -174,7 +174,7 @@ runs:
       uses: actions/cache@v3
       if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
-        key: ${{ steps.set-outputs.outputs.base-cachel-level-3 }}
+        key: ${{ steps.set-outputs.outputs.base-cache-key-level-3 }}
         path: |
           ~/.cargo/bin/
           ./target/

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -123,8 +123,8 @@ runs:
         echo "base-cache-key-level-3=$base_cache_level_3" >> $GITHUB_OUTPUT
 
         ext_cache_level_1="${base_cache_level_1}__${{ hashFiles('**/extconf.rb') }}"``
-        ext_cache_level_2="${ext_cache_level_2}__${{ hashFiles('**/Gemfile') }}"``
-        ext_cache_level_3="${ext_cache_level_3}__${{ hashFiles('**/Gemfile.lock') }}"``
+        ext_cache_level_2="${ext_cache_level_1}__${{ hashFiles('**/Gemfile') }}"``
+        ext_cache_level_3="${ext_cache_level_2}__${{ hashFiles('**/Gemfile.lock') }}"``
         echo "ext-cache-key-level-1=$ext_cache_level_1" >> $GITHUB_OUTPUT
         echo "ext-cache-key-level-2=$ext_cache_level_2" >> $GITHUB_OUTPUT
         echo "ext-cache-key-level-3=$ext_cache_level_3" >> $GITHUB_OUTPUT

--- a/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
+++ b/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
@@ -17,7 +17,7 @@ end
 end
 
 cache_key = cargo_registry_cache_keys[0]
-restore_keys = cargo_registry_cache_keys[1..-1].join("%0A")
+restore_keys = cargo_registry_cache_keys[1..-1].join("'%0A'")
 
 File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
   f.puts "cargo-registry-cache-key=\"#{cache_key}\""

--- a/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
+++ b/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
@@ -6,20 +6,19 @@ require "securerandom"
 cargo_registry_cache_keys = []
 prefix = "cr"
 
-(0..12).each do |i|
-  cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60)).strftime("%Y%m%d%H")}"
-end
-
-(0..21).each do |i|
+(0..9).each do |i|
   cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60 * 24)).strftime("%Y%m%d")}"
 end
 
-(0..3).each do |i|
+(0..1).each do |i|
   cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60 * 24 * 30)).strftime("%Y%m")}"
 end
 
 cache_key = cargo_registry_cache_keys[0]
 restore_keys = cargo_registry_cache_keys[1..-1].join("\n")
+
+raise 'too many keys' if restore_keys.count("\n") > 10
+raise 'not enough keys' if restore_keys.count("\n") < 10
 
 def set_output(key, value)
   eol = $/

--- a/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
+++ b/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
@@ -1,6 +1,8 @@
 # This script generates cache keys for the cargo registry cache. Since the cargo
 # registry is a moving target, we generate cache keys based on some recent dates.
 
+require "securerandom"
+
 cargo_registry_cache_keys = []
 prefix = "cr"
 
@@ -17,9 +19,16 @@ end
 end
 
 cache_key = cargo_registry_cache_keys[0]
-restore_keys = cargo_registry_cache_keys[1..-1].join("'%0A'")
+restore_keys = cargo_registry_cache_keys[1..-1].join("\n")
+
+def set_output(key, value)
+  eol = $/
+  delimiter = "ghadelimiter_#{SecureRandom.uuid}"
+
+  "#{key}<<#{delimiter}#{eol}#{value}#{eol}#{delimiter}#{eol}"
+end
 
 File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |f|
-  f.puts "cargo-registry-cache-key=\"#{cache_key}\""
-  f.puts "cargo-registry-restore-keys=\"#{restore_keys}\""
+  f.write set_output("cargo-registry-cache-key", cache_key)
+  f.write set_output("cargo-registry-restore-keys", restore_keys)
 end

--- a/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
+++ b/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
@@ -6,7 +6,7 @@ require "securerandom"
 cargo_registry_cache_keys = []
 prefix = "cr"
 
-(0..8).each do |i|
+(0..7).each do |i|
   cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60 * 24)).strftime("%Y%m%d")}"
 end
 

--- a/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
+++ b/setup-ruby-and-rust/helpers/cargo_registry_cache_keys.rb
@@ -6,7 +6,7 @@ require "securerandom"
 cargo_registry_cache_keys = []
 prefix = "cr"
 
-(0..9).each do |i|
+(0..8).each do |i|
   cargo_registry_cache_keys << "#{prefix}#{(Time.now - (i * 60 * 60 * 24)).strftime("%Y%m%d")}"
 end
 
@@ -17,8 +17,8 @@ end
 cache_key = cargo_registry_cache_keys[0]
 restore_keys = cargo_registry_cache_keys[1..-1].join("\n")
 
-raise 'too many keys' if restore_keys.count("\n") > 10
-raise 'not enough keys' if restore_keys.count("\n") < 10
+# raise 'too many keys' if restore_keys.split("\n").size > 10
+# raise 'not enough keys' if restore_keys.split("\n").size < 10
 
 def set_output(key, value)
   eol = $/

--- a/setup-ruby-and-rust/test.rb
+++ b/setup-ruby-and-rust/test.rb
@@ -8,10 +8,33 @@ end
 require "maxitest/autorun"
 require "json"
 
-OUTPUTS = JSON.parse(ENV.fetch("SETUP_OUTPUTS"))
+OUTPUTS = begin
+  JSON.parse(ENV.fetch("SETUP_OUTPUTS"))
+rescue KeyError
+  raise if ENV["CI"]
+
+  {
+    "ruby-platform" => RbConfig::CONFIG["arch"],
+    "ruby-prefix" => RbConfig::CONFIG["prefix"],
+    "base-cache-key-level-1" => "v0__test__it",
+  }
+end
 
 describe "setup-ruby-and-ruby" do
   describe "output validation" do
+    OUTPUTS.each do |key, value|
+      next unless key.include?("cache-key")
+
+      it "has a valid value for #{key.inspect}" do
+        assert value !~ /__\s*__/
+        assert !value.start_with?("__")
+        assert !value.end_with?("__")
+        assert value.start_with?("v")
+
+        assert value.split("__").uniq.size == value.split("__").size
+      end
+    end
+
     it "has has a valid ruby-platform" do
       assert_equal RbConfig::CONFIG["arch"], OUTPUTS["ruby-platform"]
     end

--- a/setup-ruby-and-rust/test.rb
+++ b/setup-ruby-and-rust/test.rb
@@ -12,13 +12,6 @@ OUTPUTS = JSON.parse(ENV.fetch("SETUP_OUTPUTS"))
 
 describe "setup-ruby-and-ruby" do
   describe "output validation" do
-    it "has has a valid cache-key" do
-      parts = OUTPUTS["cache-key"].split("__")
-
-      assert_equal 7, parts.size
-      assert parts.all? { |part| !part.strip.empty? }
-    end
-
     it "has has a valid ruby-platform" do
       assert_equal RbConfig::CONFIG["arch"], OUTPUTS["ruby-platform"]
     end


### PR DESCRIPTION
Turned out `sccache` was a bit slower than expected in the real `rb-sys` pipeline. This PR makes `tarball` the default again, but makes it better:

- separate cache invalidation for `./target`, and `./tmp`
- smarter cache invalidation keys
- fix cargo registry caching