### PR TITLE
Cache the entire `tmp/${{ ruby-platform }}`

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -111,6 +111,7 @@ runs:
       run: |
         : Set outputs
         ruby_platform="$(rbconfig arch)"
+        ruby_version="$(rbconfig MAJOR).$(rbconfig MINOR).$(rbconfig TEENY)"
 
         echo "ruby-prefix=$(rbconfig prefix)" >> $GITHUB_OUTPUT
         echo "ruby-platform=$ruby_platform" >> $GITHUB_OUTPUT
@@ -122,7 +123,7 @@ runs:
         echo "base-cache-key-level-2=$base_cache_level_2" >> $GITHUB_OUTPUT
         echo "base-cache-key-level-3=$base_cache_level_3" >> $GITHUB_OUTPUT
 
-        ext_cache_level_1="${base_cache_level_1}__${{ hashFiles('**/extconf.rb') }}"``
+        ext_cache_level_1="${base_cache_level_1}__${ruby_version}_${{ hashFiles('**/extconf.rb') }}"``
         ext_cache_level_2="${ext_cache_level_1}__${{ hashFiles('**/Gemfile') }}"``
         ext_cache_level_3="${ext_cache_level_2}__${{ hashFiles('**/Gemfile.lock') }}"``
         echo "ext-cache-key-level-1=$ext_cache_level_1" >> $GITHUB_OUTPUT
@@ -189,7 +190,7 @@ runs:
       with:
         key: ${{ steps.set-outputs.outputs.ext-cache-key-level-3 }}
         path: |
-          **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/target/
+          **/tmp/${{ steps.set-outputs.outputs.ruby-platform }}/
           ${{ inputs.cargo-cache-extra-path }}
         restore-keys: |
           ${{ steps.set-outputs.outputs.ext-cache-key-level-2 }}


### PR DESCRIPTION
I've been looking into speeding up wasmtime-rb's GitHub workflows and noticed we recompile _all_ crates, always. Turns out we're trying to cache `tmp/${{ ruby-platform }}/target/` which does not exist. This PR changes that by caching `tmp/${{ ruby-platform }}/` (no `target` dir).

On wasmtime-rb, the folder structure is `tmp/{platform}/wasmtime_rb/{ruby-version}/target`. Here's what I get when I run `tree -d` with a certain depth limit[1]:

```
tmp
└── x86_64-linux
    ├── stage
    │   ├── ext
    │   │   └── src
    │   │       ├── helpers
    │   │       └── ruby_api
    │   └── lib
    │       └── wasmtime
    └── wasmtime_rb
        └── 3.1.3
            └── target
                └── release
                    ├── build
                    ├── deps
                    ├── examples
                    └── incremental
```
This change will also cache `stage` -- I think it's fine, but unsure.

I added the ruby version to the cache key given the `target` dir is nested under a ruby version, and also because the extension must be recompiled for each minor Ruby version bumps.

The result for wasmtime-rb is compile time is roughly halved ([before](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3833573797/jobs/6525164828), [after](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3833748821/jobs/6525501966)).

----

One thing that's puzzling me is that we're still re-compiling _some_ crates even though they didn't change, and that list of crate is the same across builds (visible in the logs from the [after build](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3833748821/jobs/6525501966) previously linked). Let me know if you know why that is.

[1]: https://github.com/bytecodealliance/wasmtime-rb/actions/runs/3824179901/jobs/6506092845