### PR TITLE
Use `oxidize-rb/actions/cargo-binstall` to install `cargo-cache`

### DIFF
--- a/.github/workflows/test-cargo-binstall.yml
+++ b/.github/workflows/test-cargo-binstall.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - "cargo-binstall/**/*"
       - ".github/workflows/test-fetch-ci-data.yml"
-    pull_request: {}
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test-fetch-ci-data.yml
+++ b/.github/workflows/test-fetch-ci-data.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - "fetch-ci-data/**/*"
       - ".github/workflows/test-fetch-ci-data.yml"
-    pull_request: {}
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           rustup-toolchain: ${{ matrix.rust }}
-          cache-version: v0
+          cache-version: v1-${{ matrix.slug }}
           bundler-cache: true
           cargo-cache: ${{ matrix.cargo-cache }}
           cargo-cache-clean: true

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -44,7 +44,7 @@ jobs:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
               ref: main
-              run: bundle exec rake compile ruby_test cargo_test
+              run: bundle exec rake
           - os: "windows-latest"
             slug: magnus
             ruby: "mswin"

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -44,7 +44,7 @@ jobs:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
               ref: main
-              run: bundle exec rake
+              run: bundle exec rake compile ruby_test cargo_test
           - os: "windows-latest"
             slug: magnus
             ruby: "mswin"

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -20,7 +20,7 @@ jobs:
             run: bundle exec rake
           - name: "matsadler/magnus"
             slug: magnus
-            ref: 855cc11a73e536083e37bb89d5e101a02a748150
+            ref: main
             run: cargo test
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -105,8 +105,18 @@ runs:
         targets: ${{ inputs.rustup-targets }}
         components: ${{ inputs.rustup-components }}
 
-    - run: rustup toolchain list
+    - name: Clean out alternative Windows toolchains (to avoid compiler conflicts)
       shell: bash
+      if: runner.os == 'Windows'
+      run: |
+        IFS=$'\n\t'
+
+        for toolchain in $(rustup toolchain list); do
+          if [[ "$toolchain" != *"default"* ]]; then
+            echo "Uninstalling $toolchain"
+            rustup toolchain uninstall "$toolchain"
+          fi
+        done
 
     - name: Set outputs
       id: set-outputs

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -105,6 +105,9 @@ runs:
         targets: ${{ inputs.rustup-targets }}
         components: ${{ inputs.rustup-components }}
 
+    - run: rustup toolchain list
+      shell: bash
+
     - name: Set outputs
       id: set-outputs
       shell: bash
@@ -226,12 +229,12 @@ runs:
         echo "SCCACHE_GHA_CACHE_FROM=$cache_from" >> $GITHUB_ENV
         echo "SCCACHE_GHA_CACHE_TO=$cache_to" >> $GITHUB_ENV
 
-    - name: Set Path for Ruby libdir (windows)
-      if: runner.os == 'Windows' && inputs.ruby-version != 'none'
-      shell: bash
-      run: |
-        echo "$Path"
-        echo "Path=\"$(rbconfig libdir | sed 's:/:\\:g');$Path\"" >> $GITHUB_ENV
+    # - name: Set Path for Ruby libdir (windows)
+    #   if: runner.os == 'Windows' && inputs.ruby-version != 'none'
+    #   shell: bash
+    #   run: |
+    #     echo "$Path"
+    #     echo "Path=\"$(rbconfig libdir | sed 's:/:\\:g');$Path\"" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -239,13 +239,6 @@ runs:
         echo "SCCACHE_GHA_CACHE_FROM=$cache_from" >> $GITHUB_ENV
         echo "SCCACHE_GHA_CACHE_TO=$cache_to" >> $GITHUB_ENV
 
-    # - name: Set Path for Ruby libdir (windows)
-    #   if: runner.os == 'Windows' && inputs.ruby-version != 'none'
-    #   shell: bash
-    #   run: |
-    #     echo "$Path"
-    #     echo "Path=\"$(rbconfig libdir | sed 's:/:\\:g');$Path\"" >> $GITHUB_ENV
-
     - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'
       shell: bash

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -226,7 +226,12 @@ runs:
         echo "SCCACHE_GHA_CACHE_FROM=$cache_from" >> $GITHUB_ENV
         echo "SCCACHE_GHA_CACHE_TO=$cache_to" >> $GITHUB_ENV
 
-    - name: Set LD_LIBRARY_PATH for Ruby
+    - name: Set Path for Ruby libdir (windows)
+      if: runner.os == 'Windows' && inputs.ruby-version != 'none'
+      shell: bash
+      run: echo "$(rbconfig libdir)" >> $GITHUB_PATH
+
+    - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'
       shell: bash
       run: |

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -229,7 +229,7 @@ runs:
     - name: Set Path for Ruby libdir (windows)
       if: runner.os == 'Windows' && inputs.ruby-version != 'none'
       shell: bash
-      run: echo "$(rbconfig libdir)" >> $GITHUB_PATH
+      run: echo "Path=$(rbconfig libdir);$Path" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -141,24 +141,13 @@ runs:
           echo "cargo-cache=${{ inputs.cargo-cache }}" >> $GITHUB_OUTPUT
         fi
 
-    - name: Cache the "cargo-cache" executable
-      uses: actions/cache@v3
-      if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
-      with:
-        path: ~/.setup-ruby-and-rust/bin/cargo-cache
-        key: ${{ steps.set-outputs.outputs.ruby-platform }}-cargo-cache-clean-0.8.3
-
     - name: Install cargo-cache
+      uses: oxidize-rb/actions/cargo-binstall@main
       id: install-cargo-cache
       if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
-      shell: bash
-      run: |
-        : Setup cargo-cache
-        if [ ! -f "$HOME/.setup-ruby-and-rust/bin/cargo-cache" ]; then
-          cargo install --features ci-autoclean cargo-cache --root "$HOME/.setup-ruby-and-rust" --version 0.8.3
-        fi
-
-        echo "$HOME/.setup-ruby-and-rust/bin" >> $GITHUB_PATH
+      with:
+        crate: cargo-cache
+        version: 0.8.3
 
     - name: Cargo registry cache
       uses: actions/cache@v3

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -229,7 +229,9 @@ runs:
     - name: Set Path for Ruby libdir (windows)
       if: runner.os == 'Windows' && inputs.ruby-version != 'none'
       shell: bash
-      run: echo "LIB=$(rbconfig libdir | sed 's:/:\\:g');$LIB" >> $GITHUB_ENV
+      run: |
+        echo "$Path"
+        echo "Path=\"$(rbconfig libdir | sed 's:/:\\:g');$Path\"" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -229,7 +229,7 @@ runs:
     - name: Set Path for Ruby libdir (windows)
       if: runner.os == 'Windows' && inputs.ruby-version != 'none'
       shell: bash
-      run: echo "LIB=$(rbconfig libdir);$LIB" >> $GITHUB_ENV
+      run: echo "LIB=$(rbconfig libdir | sed 's:/:\\:g');$LIB" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -229,7 +229,7 @@ runs:
     - name: Set Path for Ruby libdir (windows)
       if: runner.os == 'Windows' && inputs.ruby-version != 'none'
       shell: bash
-      run: echo "Path=$(rbconfig libdir);$Path" >> $GITHUB_ENV
+      run: echo "LIB=$(rbconfig libdir);$LIB" >> $GITHUB_ENV
 
     - name: Set LD_LIBRARY_PATH for Ruby (linux)
       if: runner.os == 'Linux' && inputs.ruby-version != 'none'


### PR DESCRIPTION
The previous way of installing relied con compiling with `cargo install cargo-cache`, then caching the result with GHA cache. The cache gets busted semi-frequently, enough to make the compile times a nuisance. This PR fixes that.