### PR TITLE
Fix a bug in oxidize-rb/actions/cross-gem example

### DIFF
--- a/cross-gem/readme.md
+++ b/cross-gem/readme.md
@@ -44,7 +44,7 @@ jobs:
       - uses: oxidize-rb/actions/cross-gem@v1
         id: cross-gem
         with:
-          platform: ${{ matrix.ruby-platform }}
+          platform: ${{ matrix.platform }}
           ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
 
       - uses: actions/upload-artifact@v2


### PR DESCRIPTION
In the strategy -> matrix the variable is named `platform` but then later `ruby-platform` was used for it