### PR TITLE
Use libclang v15 on mingw builds

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -70,7 +70,7 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         cache-version: ${{ inputs.cache-version }}
         rubygems: ${{ inputs.rubygems }}
-        mingw: clang
+        mingw: clang-15
 
     - name: Install helpers
       shell: bash


### PR DESCRIPTION
This does _not_ actually solve #20, but at least it gets us a new error (finding `strings.h`).