### PR TITLE
Carefully construct bindgen environment for mingw / ucrt envs

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -279,9 +279,9 @@ runs:
         msys_root=""
 
         if [ "$MSYSTEM" = "MINGW64" ]; then
-          msys_root="$RI_DEVKIT/mingw64"
+          msys_root="c:/msys64/mingw64"
         elif [ "$MSYSTEM" = "UCRT64" ]; then
-          msys_root="$RI_DEVKIT/ucrt64"
+          msys_root="c:/msys64/ucrt64"
         else
           echo "Unknown MSYSTEM: $MSYSTEM, cannot configure bindgen"
           exit 1

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -271,7 +271,7 @@ runs:
         echo BINDGEN_EXTRA_CLANG_ARGS="-I$((gcm clang).source -replace 'bin\clang.exe', 'include')" >> $env:GITHUB_ENV
 
     - name: Configure bindgen
-      if: contains(steps.derive-toolchain.outputs.toolchain, 'pc-windows-gnu') == false
+      if: contains(steps.derive-toolchain.outputs.toolchain, 'pc-windows-gnu')
       shell: bash
       run: |
         : Configure bindgen for msys2

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -70,6 +70,8 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         cache-version: ${{ inputs.cache-version }}
         rubygems: ${{ inputs.rubygems }}
+        # for now we have to use clang-15 for mingw builds, since our bindgen is too old to work with clang-16
+        mingw: clang-15
 
     - name: Install helpers
       shell: bash
@@ -93,13 +95,6 @@ runs:
         : Derive toolchain
         derived_toolchain="$(ruby --disable-gems $GITHUB_ACTION_PATH/helpers/derive_toolchain.rb ${{ inputs.rustup-toolchain }})"
         echo "toolchain=$derived_toolchain" >> $GITHUB_OUTPUT
-
-    - name: Warn broken mingw toolchain
-      if: contains(steps.derive-toolchain.outputs.toolchain, 'pc-windows-gnu')
-      shell: bash
-      run: |
-        : Warn broken mingw toolchain
-        echo "::warning::There is known issue with the mingw toolchain which may cause your rb-sys CI builds to fail 😢. Consider temporarily disabling Windows builds until https://github.com/oxidize-rb/actions/issues/20 is resolved #helpwanted."
 
     - uses: dtolnay/rust-toolchain@master
       id: rust-toolchain
@@ -272,5 +267,30 @@ runs:
       if: contains(steps.derive-toolchain.outputs.toolchain, 'msvc')
       shell: pwsh
       run: |
-        echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-        echo "BINDGEN_EXTRA_CLANG_ARGS=$((gcm clang).source -replace "bin\clang.exe","include")" >> $env:GITHUB_ENV
+        echo LIBCLANG_PATH="$((gcm clang).source -replace 'clang.exe')" >> $env:GITHUB_ENV
+        echo BINDGEN_EXTRA_CLANG_ARGS="-I$((gcm clang).source -replace 'bin\clang.exe', 'include')" >> $env:GITHUB_ENV
+
+    - name: Configure bindgen
+      if: contains(steps.derive-toolchain.outputs.toolchain, 'pc-windows-gnu') == false
+      shell: bash
+      run: |
+        : Configure bindgen for msys2
+
+        msys_root=""
+
+        if [ "$MSYSTEM" = "MINGW64" ]; then
+          msys_root="$RI_DEVKIT/mingw64"
+        elif [ "$MSYSTEM" = "UCRT64" ]; then
+          msys_root="$RI_DEVKIT/ucrt64"
+        else
+          echo "Unknown MSYSTEM: $MSYSTEM, cannot configure bindgen"
+          exit 1
+        fi
+
+        # We can't use llvm-16 just yet due to backwards compatibility issues, so we have to workaround for now
+        echo MSYS_ROOT="$msys_root" >> $GITHUB_ENV
+        echo LIBCLANG_PATH="$msys_root/opt/llvm-15/bin" >> $GITHUB_ENV
+        echo BINDGEN_EXTRA_CLANG_ARGS="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root" >> $GITHUB_ENV
+
+        echo "::info::Set LIBCLANG_PATH to $LIBCLANG_PATH"
+        echo "::info::Set BINDGEN_EXTRA_CLANG_ARGS to $BINDGEN_EXTRA_CLANG_ARGS"


### PR DESCRIPTION
Turns out that with the downgrade to `clang-15`, all of the clang / llvm stuff got installed in the `/{mingw64,ucrt64}/opt/llvm-15/` directory, whereas it used to live in the root (`/{mingw64,ucrt64}`). Thus, bindgen was using the msvc version of clang which broke everything.

fixes #20