### PR TITLE
Always save the install cache by default

### DIFF
--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -40,7 +40,7 @@ jobs:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
               ref: main
-              run: bundle exec rake || echo "::warning::bundle exec rake failed on mswin"
+              run: bundle exec rake
           - os: "windows-latest"
             ruby: "mswin"
             experimental: true
@@ -50,7 +50,9 @@ jobs:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
               ref: main
-              run: bundle exec rake
+              run: |
+                set +euo pipefail
+                bundle exec rake || echo "::warning::bundle exec rake failed on mswin" && exit 0
           - os: "windows-latest"
             slug: magnus
             ruby: "mswin"
@@ -61,7 +63,9 @@ jobs:
               name: "matsadler/magnus"
               slug: magnus
               ref: main
-              run: cargo test -- --nocapture || echo "::warning::cargo test failed on mswin"
+              run: |
+                set +euo pipefail
+                cargo test -- --nocapture || echo "::warning::cargo test failed on mswin" && exit 0
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -52,7 +52,9 @@ jobs:
               ref: main
               run: |
                 set +euo pipefail
-                bundle exec rake || echo "::warning::bundle exec rake failed on mswin" && exit 0
+                if ! bundle exec rake; then
+                  echo "::warning::bundle exec rake failed on mswin"
+                fi
           - os: "windows-latest"
             slug: magnus
             ruby: "mswin"
@@ -65,7 +67,9 @@ jobs:
               ref: main
               run: |
                 set +euo pipefail
-                cargo test -- --nocapture || echo "::warning::cargo test failed on mswin" && exit 0
+                if ! cargo test -- --nocapture; then
+                  echo "::warning::cargo test failed on mswin"
+                fi
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -50,11 +50,7 @@ jobs:
               name: "oxidize-rb/oxi-test"
               slug: oxi-test
               ref: main
-              run: |
-                set +euo pipefail
-                if ! bundle exec rake; then
-                  echo "::warning::bundle exec rake failed on mswin"
-                fi
+              run: bundle exec rake || echo "::warning::bundle exec rake failed on mswin"
           - os: "windows-latest"
             slug: magnus
             ruby: "mswin"
@@ -65,11 +61,7 @@ jobs:
               name: "matsadler/magnus"
               slug: magnus
               ref: main
-              run: |
-                set +euo pipefail
-                if ! cargo test -- --nocapture; then
-                  echo "::warning::cargo test failed on mswin"
-                fi
+              run: cargo test -- --nocapture || echo "::warning::cargo test failed on mswin"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -100,4 +92,5 @@ jobs:
           SETUP_OUTPUTS: ${{ toJSON(steps.setup.outputs) }}
         run: ruby ./tmp/actions/setup-ruby-and-rust/test.rb -v
       - name: Run tests for ${{ matrix.repo.name }}
+        shell: bash
         run: ${{ matrix.repo.run }}

--- a/cross-gem/action.yml
+++ b/cross-gem/action.yml
@@ -24,6 +24,9 @@ inputs:
   cargo-cache-clean:
     description: "Whether to clean the cargo cache after the build."
     default: "true"
+  cache-save-always:
+    description: "Whether to save the cache even if the build fails."
+    default: "true"
 outputs:
   gem-path:
     description: "The path to the cross-compiled gem"
@@ -48,6 +51,7 @@ runs:
           ${{ env.RB_SYS_DOCK_CACHE_DIR }}
           ${{ inputs.working-directory }}/tmp/rb-sys-dock/${{ inputs.platform }}/target
         key: rb-sys-dock-${{ inputs.cache-version }}-${{ inputs.platform }}-${{ hashFiles('**/Gemfile.lock', '**/Cargo.lock') }}
+        save-always: ${{ inputs.cache-save-always == 'true' }}
         restore-keys: |
           rb-sys-dock-${{ inputs.cache-version }}-${{ inputs.platform }}-
 

--- a/cross-gem/action.yml
+++ b/cross-gem/action.yml
@@ -70,6 +70,7 @@ runs:
       with:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
+        always: ${{ inputs.cache-save-always == 'true' }}
 
     - name: Build gem
       shell: bash

--- a/cross-gem/readme.md
+++ b/cross-gem/readme.md
@@ -59,6 +59,7 @@ jobs:
 
 | Name                  | Description                                                                                                                      | Default   |
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------- |
+| **cache-save-always** | Whether to save the cache even if the build fails.                                                                               | `true`    |
 | **cache-version**     | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache. | `v0`      |
 | **cargo-cache-clean** | Whether to clean the cargo cache after the build.                                                                                | `true`    |
 | **platform**          | The platform to cross-compile for (e.g. `x86_64-linux`)                                                                          |           |

--- a/post-run/action.yml
+++ b/post-run/action.yml
@@ -10,9 +10,13 @@ inputs:
   cwd:
     description: "A working directory from which the command needs to be run."
     required: false
+  always:
+    description: "Always run, even if the job fails."
+    required: false
+    default: "false"
 
 runs:
-  using: node16
+  using: node20
   main: main.js
   post: post.js
-  post-if: success()
+  post-if: success() || ${{ inputs.always == 'true' }}

--- a/post-run/readme.md
+++ b/post-run/readme.md
@@ -22,10 +22,11 @@ jobs:
 
 <!-- inputs -->
 
-| Name    | Description                                                 | Default                                   |
-| ------- | ----------------------------------------------------------- | ----------------------------------------- |
-| **cwd** | A working directory from which the command needs to be run. |                                           |
-| **run** | A command that needs to be run.                             | `echo "This is a post-action command..."` |
+| Name       | Description                                                 | Default                                   |
+| ---------- | ----------------------------------------------------------- | ----------------------------------------- |
+| **always** | Always run, even if the job fails.                          | `false`                                   |
+| **cwd**    | A working directory from which the command needs to be run. |                                           |
+| **run**    | A command that needs to be run.                             | `echo "This is a post-action command..."` |
 
 <!-- /inputs -->
 

--- a/readme.md
+++ b/readme.md
@@ -1,37 +1,35 @@
 # ⚡️ Ruby on Rust GitHub Actions
 
-This repo contains a collection of GitHub Actions for your Ruby on Rust projects.
+This repository features a curated suite of GitHub Actions designed for Ruby on Rust projects, making it easier to set up and test native Rust gems within Ruby environments.
 
-## 📦 Actions
+## 📦 Available Actions
 
-### `oxidize-rb/actions/setup-ruby-and-rust@v1`
+### Setup Ruby and Rust (`oxidize-rb/actions/setup-ruby-and-rust@v1`)
 
-A GitHub Action that sets up a Ruby environment and Rust environment for use
-testing native Rust gems.
+⚙️ A GitHub Action that prepares both Ruby and Rust environments, aimed at facilitating the testing of native Rust gems.
 
-[📝 Read the Docs](./setup-ruby-and-rust/readme.md)
+- [📝 Documentation](./setup-ruby-and-rust/readme.md)
 
-### `oxidize-rb/actions/cross-gem@v1`
+### Cross-Compile Ruby Gems (`oxidize-rb/actions/cross-gem@v1`)
 
-A GitHub action to cross-compile a Ruby gem for multiple platforms using
-`rb-sys-dock`.
+🌍 This action enables the cross-compilation of Ruby gems for various platforms using `rb-sys-dock`, enhancing the accessibility of Ruby gems across different systems.
 
-[📝 Read the Docs](./cross-gem/readme.md)
+- [📝 Documentation](./cross-gem/readme.md)
 
-### `oxidize-rb/actions/fetch-ci-data@v1`
+### Fetch CI Data (`oxidize-rb/actions/fetch-ci-data@v1`)
 
-A GitHub Action to query useful CI data for usage in a matrix, etc.
+🔍 Retrieves essential Continuous Integration (CI) data, useful for optimizing CI matrix configurations and other automated processes.
 
-[📝 Read the Docs](./fetch-ci-data/readme.md)
+- [📝 Documentation](./fetch-ci-data/readme.md)
 
-### `oxidize-rb/actions/cargo-binstall@v1`
+### Cargo Binary Installer (`oxidize-rb/actions/cargo-binstall@v1`)
 
-A GitHub action to download and install binaries using `cargo-binstall`.
+📦 Simplifies downloading and installing binaries with `cargo-binstall`, streamlining the integration of Rust binaries into projects.
 
-[📝 Read the Docs](./cargo-binstall/readme.md)
+- [📝 Documentation](./cargo-binstall/readme.md)
 
-### `oxidize-rb/actions/post-run@v1`
+### Post-Run Command (`oxidize-rb/actions/post-run@v1`)
 
-Simple action to run a command after a job has finished.
+🏁 A concise action for executing commands post-job completion, assisting in clean-up or further setup steps.
 
-[📝 Read the Docs](./post-run/readme.md)
+- [📝 Documentation](./post-run/readme.md)

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -235,6 +235,7 @@ runs:
       with:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
+        always: ${{ inputs.cache-save-always == 'true' }}
 
     - name: Install sccache
       uses: oxidize-rb/actions/cargo-binstall@v1

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -49,6 +49,9 @@ inputs:
   debug:
     description: "Enable verbose debugging info (includes summary of action)"
     default: "false"
+  cache-save-always:
+    description: "Whether to save the cache even if the build fails."
+    default: "true"
 outputs:
   ruby-prefix:
     description: "The prefix of the installed ruby"
@@ -211,6 +214,7 @@ runs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
+        save-always: ${{ inputs.cache-save-always == 'true' }}
 
     - name: Setup base cargo cache
       uses: actions/cache@v4
@@ -223,6 +227,7 @@ runs:
         restore-keys: |
           ${{ steps.set-outputs.outputs.base-cache-key-level-2 }}
           ${{ steps.set-outputs.outputs.base-cache-key-level-1 }}
+        save-always: ${{ inputs.cache-save-always == 'true' }}
 
     - name: Clean the cargo cache
       if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -48,6 +48,7 @@ jobs:
 | Name                       | Description                                                                                                                                                 | Default           |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
 | **bundler-cache**          | Run "bundle install", and cache the result automatically. Either true or false.                                                                             | `false`           |
+| **cache-save-always**      | Whether to save the cache even if the build fails.                                                                                                          | `true`            |
 | **cache-version**          | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache.                            | `v0`              |
 | **cargo-cache**            | Strategy to use for caching build artifacts (either 'sccache', 'tarball', or 'false')                                                                       | `default`         |
 | **cargo-cache-clean**      | Clean the cargo cache with cargo cache --autoclean                                                                                                          | `true`            |


### PR DESCRIPTION
A failing build shouldn't cause subsequent builds to be unnecessarily slow. That's just kicking someone when they're already down. Instead, at least save the cache so the next CI run is quick.