### PR TITLE
Forward working-directory to rb-sys-dock

### DIFF
--- a/cross-gem/action.yml
+++ b/cross-gem/action.yml
@@ -74,7 +74,6 @@ runs:
 
     - name: Build gem
       shell: bash
-      working-directory: ${{ inputs.working-directory }}
       env:
         INPUT_RUBY_VERSIONS: "${{ inputs.ruby-versions }}"
         INPUT_TAG: "${{ inputs.tag }}"
@@ -83,11 +82,18 @@ runs:
         INPUT_POST_SCRIPT: "${{ inputs.post-script }}"
       run: |
         : Compile gem
+        echo "Docker Working Directory: $(pwd)"
+        echo "Gem Working Directory: ${{ inputs.working-directory }}"
         set -x
 
         args=()
         args+=("--platform")
         args+=("$INPUT_PLATFORM")
+
+        if [ -n "${{ inputs.working-directory }}" ]; then
+          args+=("--directory")
+          args+=("${{ inputs.working-directory }}")
+        fi
 
         if [ "$INPUT_RUBY_VERSIONS" != "default" ]; then
           args+=("--ruby-versions")
@@ -102,7 +108,10 @@ runs:
         if bundle info rb_sys > /dev/null; then
           bundle exec rb-sys-dock "${args[@]}" --build
         else
+          cwd=$(pwd)
+          cd ${{ inputs.working-directory }}
           gem install rb_sys
+          cd $cwd
           rb-sys-dock "${args[@]}" --build
         fi
 


### PR DESCRIPTION
The action was forcing the use of the passed in "working_directory" argument in the CI step.

Now, it is instead forwarded as the "--directory" argument if provided.

Also, if rb_sys has not been installed, it will change into the working directory before attempting to install, to ensure the version specified by the gemfile is used.