### PR TITLE
Use versioned cache dir in cross-gem

### DIFF
--- a/cross-gem/action.yml
+++ b/cross-gem/action.yml
@@ -36,13 +36,16 @@ runs:
   steps:
     - name: Configure environment
       shell: bash
+      id: configure
       run: |
         : Configure environment
         echo "RB_SYS_DOCK_UID=$(id -u)" >> $GITHUB_ENV
         echo "RB_SYS_DOCK_GID=$(id -g)" >> $GITHUB_ENV
-        rb_sys_dock_cache_dir="$HOME/.cache/rb-sys-dock"
+        rb_sys_version="$((grep rb_sys Gemfile.lock | head -n 1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || (gem info rb_sys --remote | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || echo "latest")"
+        rb_sys_dock_cache_dir="$HOME/.cache/rb-sys-$rb_sys_version"
         mkdir -p "$rb_sys_dock_cache_dir"
         echo "RB_SYS_DOCK_CACHE_DIR=$rb_sys_dock_cache_dir" >> $GITHUB_ENV
+        echo "rb_sys_version=$rb_sys_version" >> $GITHUB_OUTPUT
 
     - name: Setup caching
       uses: actions/cache@v4
@@ -76,7 +79,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        version="$((grep rb_sys Gemfile.lock | head -n 1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || echo "latest")"
+        version="${{ steps.configure.outputs.rb_sys_version }}"
         echo "Installing rb_sys@$version"
         
         if [ "$version" = "latest" ]; then


### PR DESCRIPTION
Fixes the rbenv upgrade issue related to `executable_hooks` installed previously by RVM