### PR TITLE
Fix macOS bindgen issue

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -298,13 +298,18 @@ runs:
         echo "::endgroup::"
 
     - name: Configure bindgen
+      shell: bash
+      run: |
+        echo BINDGEN_EXTRA_CLANG_ARGS_aarch64-apple-darwin="-I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include" >> $GITHUB_ENV
+
+    - name: Configure bindgen (msvc)
       if: contains(steps.derive-toolchain.outputs.toolchain, 'msvc')
       shell: pwsh
       run: |
         echo LIBCLANG_PATH="$((gcm clang).source -replace 'clang.exe')" >> $env:GITHUB_ENV
         echo BINDGEN_EXTRA_CLANG_ARGS="-I$((gcm clang).source -replace 'bin\clang.exe', 'include')" >> $env:GITHUB_ENV
 
-    - name: Configure bindgen
+    - name: Configure bindgen (msys2)
       if: contains(steps.derive-toolchain.outputs.toolchain, 'pc-windows-gnu')
       shell: bash
       run: |


### PR DESCRIPTION
I started seeing the following error for macOS runners:
```
  /Users/runner/hostedtoolcache/Ruby/3.1.6/arm64/include/ruby-3.1.0/ruby/defines.h:16:10: fatal error: 'stdio.h' file not found
  thread 'main' panicked at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rb-sys-0.9.97/build/main.rs:55:6:
  generate bindings: ClangDiagnostic("/Users/runner/hostedtoolcache/Ruby/3.1.6/arm64/include/ruby-3.1.0/ruby/defines.h:16:10: fatal error: 'stdio.h' file not found\n")
```

@ianks found a workaround in https://github.com/rust-lang/rust-bindgen/discussions/2401 where we set `BINDGEN_EXTRA_CLANG_ARGS_aarch64-apple-darwin`, and it resolved the issue