### PR TITLE
Avoid upcoming `cache` action deprecation

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -15,7 +15,7 @@ inputs:
   rubygems:
     description: "Runs `gem update --system`. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info."
     required: false
-    default: 'default'
+    default: "default"
   working-directory:
     description: "The working directory to use for resolving paths for .ruby-version, .tool-versions and Gemfile.lock."
   cache-version:
@@ -214,7 +214,6 @@ runs:
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        save-always: ${{ inputs.cache-save-always == 'true' }}
 
     - name: Setup base cargo cache
       uses: actions/cache@v4
@@ -227,7 +226,6 @@ runs:
         restore-keys: |
           ${{ steps.set-outputs.outputs.base-cache-key-level-2 }}
           ${{ steps.set-outputs.outputs.base-cache-key-level-1 }}
-        save-always: ${{ inputs.cache-save-always == 'true' }}
 
     - name: Clean the cargo cache
       if: inputs.cargo-cache-clean == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
@@ -236,6 +234,27 @@ runs:
         run: cargo-cache --autoclean
         cwd: ${{ inputs.working-directory }}
         always: ${{ inputs.cache-save-always == 'true' }}
+
+    - name: Save cargo registry cache
+      id: save-cargo-registry-cache
+      if: always() && inputs.cache-save-always == 'true' && steps.set-outputs.outputs.cargo-cache != 'false'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.set-outputs.outputs.cargo-registry-cache-key }}
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+
+    - name: Save base cargo cache
+      id: save-base-cargo-cache
+      if: always() && inputs.cache-save-always == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
+      uses: actions/cache/save@v4
+      with:
+        key: ${{ steps.set-outputs.outputs.base-cache-key-level-3 }}
+        path: |
+          ~/.cargo/bin/
+          ./target/
 
     - name: Install sccache
       uses: oxidize-rb/actions/cargo-binstall@v1
@@ -255,7 +274,6 @@ runs:
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
           core.exportVariable('RUSTC_WRAPPER', process.env.RUSTC_WRAPPER || 'sccache');
           core.exportVariable('SCCACHE_C_CUSTOM_CACHE_BUSTER', '${{ inputs.cache-version }}-${{ steps.rust-toolchain.outputs.cachekey }}');
-
 
     - name: Install sccache
       if: steps.set-outputs.outputs.cargo-cache == 'sccache'


### PR DESCRIPTION
This just started popping up in my logs:

```
Input `save-always` has been deprecated with message

save-always does not work as intended and will be removed in a future release.
A separate `actions/cache/restore` step should be used instead.
See https://github.com/actions/cache/tree/main/save#always-save-cache for more details.
```

GitHub recently removed flagged the argument as deprecated: https://github.com/actions/cache/pull/1452

This PR is an attempt to work around the upcoming breakage. 