### PR TITLE
Allow to set `bundler` config of `setup-ruby`

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -9,6 +9,10 @@ inputs:
   ruby-version:
     description: "Engine and version to use, see the syntax in the README. Reads from .ruby-version or .tool-versions if unset. Can be set to 'none' to skip installing Ruby."
     default: "default"
+  bundler:
+    description: "The version of Bundler to install. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info."
+    required: false
+    default: 'default'
   bundler-cache:
     description: 'Run "bundle install", and cache the result automatically. Either true or false.'
     default: "false"
@@ -96,6 +100,7 @@ runs:
       if: inputs.ruby-version != 'none'
       with:
         ruby-version: ${{ inputs.ruby-version }}
+        bundler: ${{ inputs.bundler }}
         bundler-cache: ${{ inputs.bundler-cache }}
         working-directory: ${{ inputs.working-directory }}
         cache-version: ${{ inputs.cache-version }}

--- a/setup-ruby-and-rust/readme.md
+++ b/setup-ruby-and-rust/readme.md
@@ -47,6 +47,7 @@ jobs:
 
 | Name                       | Description                                                                                                                                                 | Default           |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| **bundler**                | The version of Bundler to install. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info.                                              | `default`         |
 | **bundler-cache**          | Run "bundle install", and cache the result automatically. Either true or false.                                                                             | `false`           |
 | **cache-save-always**      | Whether to save the cache even if the build fails.                                                                                                          | `true`            |
 | **cache-version**          | Arbitrary string that will be added to the cache key of the bundler cache. Set or change it if you need to invalidate the cache.                            | `v0`              |


### PR DESCRIPTION
I sometimes want to use the latest Bundler. `setup-ruby-pkgs` and `setup-ruby` allow to edit it via `bundler` config. 
https://github.com/ruby/setup-ruby-pkgs/blob/1493c009477b19efcb54cfaf72b5f9d1fd6ba86c/action.yml#L16-L22

This PR allows to set it from `setup-ruby-and-rust`.