### PR TITLE
Update an example to work with `@actions/upload-artifact` v4

### DIFF
--- a/cross-gem/readme.md
+++ b/cross-gem/readme.md
@@ -47,9 +47,9 @@ jobs:
           platform: ${{ matrix.platform }}
           ruby-versions: ${{ join(fromJSON(needs.ci-data.outputs.result).stable-ruby-versions, ',') }}
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
-          name: cross-gem
+          name: cross-gem-${{ matrix.platform }}
           path: ${{ steps.cross-gem.outputs.gem-path }}
 ```
 


### PR DESCRIPTION
`@actions/upload-artifact` v4 doesn't allow using the same named artifact multiple times.
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes

Because of this, the current example doesn't work with it. This PR adds a platform as a suffix of the name to fix it.