### PR TITLE
Stop pinning clang in windows ucrt

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -105,6 +105,8 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         cache-version: ${{ inputs.cache-version }}
         rubygems: ${{ inputs.rubygems }}
+        # for now we have to use clang-15 for mingw builds, since our bindgen is too old to work with clang-16
+        mingw: clang-15
 
     - name: Install helpers
       shell: bash
@@ -347,13 +349,23 @@ runs:
           exit 1
         fi
 
-        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root"
-
-        echo "::info::Listing files in $msys_root"
-        ls -la "$msys_root"
+        libclang_path="$msys_root/opt/llvm-15/bin"
+        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I'C:\Program Files\LLVM\lib\clang\18\include'"
 
         echo "::info::List clang include dir"
         echo "int main() { return 0; }" > foo.c && clang foo.c -v
 
-        echo "::info::Set BINDGEN_EXTRA_CLANG_ARGS to $bindgen_extra_clang_args"
+        echo "::info::Listing files in $libclang_path"
+        ls -la "$libclang_path"
+        echo "::info::Listing files in $msys_root"
+        ls -la "$msys_root"
+
+        # We can't use llvm-16 just yet due to backwards compatibility issues, so we have to workaround for now
+        echo MSYS_ROOT="$msys_root" >> $GITHUB_ENV
+        echo LIBCLANG_PATH="$libclang_path" >> $GITHUB_ENV
+        echo "$libclang_path" >> $GITHUB_PATH
         echo BINDGEN_EXTRA_CLANG_ARGS="$bindgen_extra_clang_args" >> $GITHUB_ENV
+
+
+        echo "::info::Set LIBCLANG_PATH to $libclang_path"
+        echo "::info::Set BINDGEN_EXTRA_CLANG_ARGS to $bindgen_extra_clang_args"

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -350,19 +350,19 @@ runs:
         fi
 
         libclang_path="$msys_root/opt/llvm-15/bin"
-        tmp_dir=$(expander "%TMP%")
-        mkdir $tmp_dir\extra-includes
+        extra_includes=$msys_root/opt/extra-includes
 
+        echo $extra_includes
+        mkdir -p $extra_includes
 
-        echo "::info::Debug"
-        echo $tmp_dir
-        ls $tmp_dir\extra-includes
+        curl https://raw.githubusercontent.com/llvm/llvm-project/refs/heads/main/clang/lib/Headers/stdckdint.h > $extra_includes/stdckdint.h
 
-        curl https://raw.githubusercontent.com/llvm/llvm-project/refs/heads/main/clang/lib/Headers/stdckdint.h > %TEMP%\extra-includes\stdckdint.h
+        echo "::info::List extra includes"
+        ls $extra_includes
         # ls 'C:\Program Files\LLVM\lib\clang\18\include'
         # cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
 
-        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I$tmp_dir\extra-includes"
+        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I$extra_includes"
 
         echo "::info::List clang include dir"
         echo "int main() { return 0; }" > foo.c && clang foo.c -v

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -105,8 +105,6 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         cache-version: ${{ inputs.cache-version }}
         rubygems: ${{ inputs.rubygems }}
-        # for now we have to use clang-15 for mingw builds, since our bindgen is too old to work with clang-16
-        mingw: clang-15
 
     - name: Install helpers
       shell: bash
@@ -349,19 +347,10 @@ runs:
           exit 1
         fi
 
-        libclang_path="$msys_root/opt/llvm-15/bin"
         bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root"
 
-        echo "::info::Listing files in $libclang_path"
-        ls -la "$libclang_path"
         echo "::info::Listing files in $msys_root"
         ls -la "$msys_root"
 
-        # We can't use llvm-16 just yet due to backwards compatibility issues, so we have to workaround for now
-        echo MSYS_ROOT="$msys_root" >> $GITHUB_ENV
-        echo LIBCLANG_PATH="$libclang_path" >> $GITHUB_ENV
-        echo "$libclang_path" >> $GITHUB_PATH
-        echo BINDGEN_EXTRA_CLANG_ARGS="$bindgen_extra_clang_args" >> $GITHUB_ENV
-
-        echo "::info::Set LIBCLANG_PATH to $libclang_path"
         echo "::info::Set BINDGEN_EXTRA_CLANG_ARGS to $bindgen_extra_clang_args"
+        echo BINDGEN_EXTRA_CLANG_ARGS="$bindgen_extra_clang_args" >> $GITHUB_ENV

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -352,5 +352,8 @@ runs:
         echo "::info::Listing files in $msys_root"
         ls -la "$msys_root"
 
+        echo "::info::List clang include dir"
+        echo "int main() { return 0; }" > foo.c && clang foo.c -v
+
         echo "::info::Set BINDGEN_EXTRA_CLANG_ARGS to $bindgen_extra_clang_args"
         echo BINDGEN_EXTRA_CLANG_ARGS="$bindgen_extra_clang_args" >> $GITHUB_ENV

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -351,7 +351,8 @@ runs:
 
         libclang_path="$msys_root/opt/llvm-15/bin"
         mkdir %TEMP%\extra-includes
-        cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
+        ls 'C:\Program Files\LLVM\lib\clang\18\include'
+        # cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
 
         bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I%TEMP%\extra-includes"
 

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -349,18 +349,11 @@ runs:
           exit 1
         fi
 
-        libclang_path="$msys_root/opt/llvm-15/bin"
-        extra_includes=$msys_root/opt/extra-includes
+        libclang_path=$msys_root/opt/llvm-15/bin
 
-        echo $extra_includes
-        mkdir -p $extra_includes
-
-        curl https://raw.githubusercontent.com/llvm/llvm-project/refs/heads/main/clang/lib/Headers/stdckdint.h > $extra_includes/stdckdint.h
-
-        echo "::info::List extra includes"
-        ls $extra_includes
-        # ls 'C:\Program Files\LLVM\lib\clang\18\include'
-        # cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
+        extra_includes=$msys_root/opt/rb-sys/include
+        mkdir -p $msys_root/opt/rb-sys/include
+        cp 'C:\Program Files\LLVM\lib\clang\18\include\stdckdint.h' $extra_includes
 
         bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I$extra_includes"
 

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -350,7 +350,10 @@ runs:
         fi
 
         libclang_path="$msys_root/opt/llvm-15/bin"
-        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I'C:\Program Files\LLVM\lib\clang\18\include'"
+        mkdir %TEMP%\extra-includes
+        cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
+
+        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I%TEMP%\extra-includes"
 
         echo "::info::List clang include dir"
         echo "int main() { return 0; }" > foo.c && clang foo.c -v

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -350,12 +350,19 @@ runs:
         fi
 
         libclang_path="$msys_root/opt/llvm-15/bin"
-        mkdir %TEMP%\extra-includes
+        tmp_dir=$(expander "%TMP%")
+        mkdir $tmp_dir\extra-includes
+
+
+        echo "::info::Debug"
+        echo $tmp_dir
+        ls $tmp_dir\extra-includes
+
         curl https://raw.githubusercontent.com/llvm/llvm-project/refs/heads/main/clang/lib/Headers/stdckdint.h > %TEMP%\extra-includes\stdckdint.h
         # ls 'C:\Program Files\LLVM\lib\clang\18\include'
         # cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
 
-        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I%TEMP%\extra-includes"
+        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I$tmp_dir\extra-includes"
 
         echo "::info::List clang include dir"
         echo "int main() { return 0; }" > foo.c && clang foo.c -v

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -351,7 +351,8 @@ runs:
 
         libclang_path="$msys_root/opt/llvm-15/bin"
         mkdir %TEMP%\extra-includes
-        ls 'C:\Program Files\LLVM\lib\clang\18\include'
+        curl https://raw.githubusercontent.com/llvm/llvm-project/refs/heads/main/clang/lib/Headers/stdckdint.h > %TEMP%\extra-includes\stdckdint.h
+        # ls 'C:\Program Files\LLVM\lib\clang\18\include'
         # cp 'C:\Program Files\LLVM\lib\clang\18\include\stdchkint.h' %TEMP%\extra-includes
 
         bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I%TEMP%\extra-includes"
@@ -364,7 +365,6 @@ runs:
         echo "::info::Listing files in $msys_root"
         ls -la "$msys_root"
 
-        # We can't use llvm-16 just yet due to backwards compatibility issues, so we have to workaround for now
         echo MSYS_ROOT="$msys_root" >> $GITHUB_ENV
         echo LIBCLANG_PATH="$libclang_path" >> $GITHUB_ENV
         echo "$libclang_path" >> $GITHUB_PATH


### PR DESCRIPTION
Ruby 3.4 + Windows is failing CI on wasmtime-rb, see [this error](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/12551032834/job/34995930549?pr=408).

Ruby 3.4 detects and uses `<stdckdint.h>` if it's present ([source](https://github.com/ruby/ruby/blob/3e8f0e558973aa8608e6d8da4dce33fe5dde28e1/include/ruby/internal/stdckdint.h#L30C11-L30C34)). For some reason, on Windows with that clang version the compiler thinks `<stdckdint.h>` is available, but then errors when `include`ing it.

I tried using the built-in clang version and looks like it worked, see this [CI run](https://github.com/bytecodealliance/wasmtime-rb/actions/runs/12583621169/job/35071587036?pr=408), hence this PR.