### PR TITLE
Set CI data to a minimum 3.3.5

### DIFF
--- a/fetch-ci-data/evaluate.rb
+++ b/fetch-ci-data/evaluate.rb
@@ -66,6 +66,9 @@ def fetch_stable_ruby_versions(inputs)
     end
   end
 
+  # See https://github.com/rake-compiler/rake-compiler-dock/blob/c4e7dc390e0757891ad8c7898953f87a35c957dc/History.md?plain=1#L53
+  # for more information on v3.3.5.
+  versions.each_with_index { |version, i| versions[i] = "3.3.5" and break if version == "3.3" }
   log(:info, "Selected Ruby versions: #{versions.join(', ')}")
 
   {"stable-ruby-versions" => versions}


### PR DESCRIPTION
See https://github.com/oxidize-rb/rb-sys/pull/475 for more information.

I've been sitting here rebuilding tiktoken_ruby, downloading the cross-gem artifacts, and trying to figure out why 3.3 still didn't have a build. I finally tracked the issue down to this check. Some actions (the ones in my projects) hard code Ruby version strings, so I didn't catch this for the situation where people are using the CI data to fetch the info.