### PR TITLE
Add stdckint.h to fix Windows + Ruby 3.4 builds

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -349,8 +349,13 @@ runs:
           exit 1
         fi
 
+        # Add stdckdint.h from LLVM 18 to prevent Ruby 3.4's header from erroring
+        extra_includes=$msys_root/opt/rb-sys/include
+        mkdir -p $msys_root/opt/rb-sys/include
+        cp 'C:\Program Files\LLVM\lib\clang\18\include\stdckdint.h' $extra_includes
+
         libclang_path="$msys_root/opt/llvm-15/bin"
-        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root"
+        bindgen_extra_clang_args="--target=${{ steps.derive-toolchain.outputs.toolchain }} --sysroot=$msys_root -I$extra_includes"
 
         echo "::info::Listing files in $libclang_path"
         ls -la "$libclang_path"


### PR DESCRIPTION
Take 2 on #47. Adding only the missing header seem to do the trick.

Test run: https://github.com/jbourassa/oxidize-rb-actions/actions/runs/12717067531