### PR TITLE
Update sccache from v0.3.3 to v0.9.1

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -266,7 +266,7 @@ runs:
       if: steps.set-outputs.outputs.cargo-cache == 'sccache'
       with:
         crate: sccache
-        version: 0.3.3
+        version: 0.9.1
         strategies: quick-install
         install-path: ${{ github.action_path }}/bin
 


### PR DESCRIPTION
This resolves the OpenSSL 1.1 dependency issue: https://github.com/oxidize-rb/rb-sys/issues/497