### PR TITLE
Fix sysroot path

### DIFF
--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -12,7 +12,7 @@ inputs:
   bundler:
     description: "The version of Bundler to install. See https://github.com/ruby/setup-ruby/blob/master/README.md for more info."
     required: false
-    default: 'default'
+    default: "default"
   bundler-cache:
     description: 'Run "bundle install", and cache the result automatically. Either true or false.'
     default: "false"
@@ -336,16 +336,7 @@ runs:
       run: |
         : Configure bindgen for msys2
 
-        msys_root=""
-
-        if [ "$MSYSTEM" = "MINGW64" ]; then
-          msys_root="c:/msys64/mingw64"
-        elif [ "$MSYSTEM" = "UCRT64" ]; then
-          msys_root="c:/msys64/ucrt64"
-        else
-          echo "Unknown MSYSTEM: $MSYSTEM, cannot configure bindgen"
-          exit 1
-        fi
+        msys_root=${RI_DEVKIT//\\/\/}$MSYSTEM_PREFIX
 
         # The preprocessor definitions are necessary to work around an incompatibility with
         # C headers included in clang 16+ and bindgen: https://github.com/rust-lang/rust-bindgen/issues/2500.


### PR DESCRIPTION
I noticed in a recent build that the path containing the sysroot changed from `c:/msys64/ucrt64` to `D:\a\_temp\rubyinstaller-3.3.5-1-x64\msys64` so I started seeing messages that looked like:

```
  thread 'main' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\rb-sys-0.9.111\build\main.rs:50:6:
  generate bindings: ClangDiagnostic("C:/hostedtoolcache/windows/Ruby/3.2.8/x64/include/ruby-3.2.0\\ruby\\defines.h:16:10: fatal error: 'stdio.h' file not found\n")
```

This change uses the `RI_DEVKIT` and `MSYSTEM_PREFIX` environment variables to determine the sysroot location. Technically the `RI_DEVKIT` environment variable isn't something _public_ per se, but I _think_ the only other alternative is having a list of possible sysroot locations and checking if they exist and this seems a bit cleaner to me.