### PR TITLE
Patch rb-sys to use main branch for CI tests

### DIFF
--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -27,7 +27,9 @@ jobs:
           - name: "matsadler/magnus"
             slug: magnus
             ref: main
-            run: cargo test -- --nocapture --skip it_includes_backtrace_in_debug
+            run: |
+              gem install power_assert
+              cargo test -- --nocapture --skip it_includes_backtrace_in_debug
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]
         ruby: ["3.0", "3.1", "3.2", "3.3", "head"]
@@ -73,7 +75,9 @@ jobs:
               name: "matsadler/magnus"
               slug: magnus
               ref: main
-              run: cargo test -- --nocapture --skip it_includes_backtrace_in_debug || echo "::warning::cargo test failed on mswin"
+              run: |
+                gem install power_assert
+                cargo test -- --nocapture --skip it_includes_backtrace_in_debug || echo "::warning::cargo test failed on mswin"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -90,18 +90,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./tmp/actions
-      
+
       - name: Patch rb-sys version to use main
+        shell: bash
         run: |
           mkdir -p .cargo
           echo "[patch.crates-io]" >> .cargo/config.toml
           echo "rb-sys = { git = \"https://github.com/oxidize-rb/rb-sys\", branch = \"main\" }" >> .cargo/config.toml
           echo "rb-sys-env = { git = \"https://github.com/oxidize-rb/rb-sys\", branch = \"main\" }" >> .cargo/config.toml
-          
+
           if [[ -f Gemfile ]]; then
             sed -i.bak "s|gem 'rb_sys', '.*'|gem 'rb_sys', github: 'oxidize-rb/rb-sys', branch: 'main'|g" Gemfile
           fi
-          
+
           if [[ -f Cargo.toml ]]; then
             cargo update -p rb-sys -p rb-sys-env || echo "No rb-sys dependencies found"
           fi

--- a/.github/workflows/test-setup-ruby-and-rust.yml
+++ b/.github/workflows/test-setup-ruby-and-rust.yml
@@ -90,6 +90,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: ./tmp/actions
+      
+      - name: Patch rb-sys version to use main
+        run: |
+          mkdir -p .cargo
+          echo "[patch.crates-io]" >> .cargo/config.toml
+          echo "rb-sys = { git = \"https://github.com/oxidize-rb/rb-sys\", branch = \"main\" }" >> .cargo/config.toml
+          echo "rb-sys-env = { git = \"https://github.com/oxidize-rb/rb-sys\", branch = \"main\" }" >> .cargo/config.toml
+          
+          if [[ -f Gemfile ]]; then
+            sed -i.bak "s|gem 'rb_sys', '.*'|gem 'rb_sys', github: 'oxidize-rb/rb-sys', branch: 'main'|g" Gemfile
+          fi
+          
+          if [[ -f Cargo.toml ]]; then
+            cargo update -p rb-sys -p rb-sys-env || echo "No rb-sys dependencies found"
+          fi
+
       - uses: ./tmp/actions/upload-core-dumps
       - uses: ./tmp/actions/setup-ruby-and-rust
         id: setup


### PR DESCRIPTION
Add step to patch rb-sys and rb-sys-env dependencies to use the latest main branch from GitHub in both Cargo and Gemfile for CI workflow.