### PR TITLE
cross-gem: wire up pre-script input to rb-sys-dock

### DIFF
--- a/cross-gem/action.yml
+++ b/cross-gem/action.yml
@@ -30,6 +30,9 @@ inputs:
   mount-toolchains:
     description: "Whether to mount cross-compilation toolchains."
     default: "false"
+  pre-script:
+    description: "A shell command to run inside the container before the gem build. Useful for installing system dependencies needed by native extensions."
+    default: ""
 outputs:
   gem-path:
     description: "The path to the cross-compiled gem"
@@ -98,7 +101,6 @@ runs:
         INPUT_TAG: "${{ inputs.tag }}"
         INPUT_PLATFORM: "${{ inputs.platform }}"
         INPUT_PRE_SCRIPT: "${{ inputs.pre-script }}"
-        INPUT_POST_SCRIPT: "${{ inputs.post-script }}"
         INPUT_MOUNT_TOOLCHAINS: "${{ inputs.mount-toolchains }}"
       run: |
         : Compile gem
@@ -128,7 +130,11 @@ runs:
           args+=("--mount-toolchains")
         fi
 
-        rb-sys-dock "${args[@]}" --build
+        if [ -n "$INPUT_PRE_SCRIPT" ]; then
+          rb-sys-dock "${args[@]}" --build -- "$INPUT_PRE_SCRIPT"
+        else
+          rb-sys-dock "${args[@]}" --build
+        fi
 
         exitcode="$?"
         echo "build_exitcode=$exitcode" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The build step already sets `INPUT_PRE_SCRIPT` as an env var referencing `inputs.pre-script`, but the input was never actually declared in the `inputs:` section — so it always resolves to an empty string. The value also never gets forwarded to `rb-sys-dock`. The net effect is that any `pre-script` passed by callers is silently ignored.

This is a problem for gems that depend on system libraries not present in the default rb-sys-dock container image. For example, `rdkafka-sys` needs `libcurl-dev` headers to compile `librdkafka`, and there's no way to install them before the build runs.

`rb-sys-dock` already supports extra commands passed as trailing arguments after `--`, which get injected into the container's build command before `rake native:$RUBY_TARGET gem`. This PR just connects the dots:

- Declares `pre-script` as a proper input (empty default, fully backwards compatible)
- Passes it to `rb-sys-dock` via `--` when non-empty
- Removes the dead `INPUT_POST_SCRIPT` env var (also undeclared and unused)

Usage:

```yaml
- uses: oxidize-rb/actions/cross-gem@v1
  with:
    platform: x86_64-linux
    ruby-versions: "3.2,3.3,3.4"
    pre-script: >-
      sudo apt-get update -qq &&
      sudo apt-get install -y -q libcurl4-openssl-dev
```