### PR TITLE
Use Node 24 in GitHub actions

### DIFF
--- a/cross-gem/action.yml
+++ b/cross-gem/action.yml
@@ -54,7 +54,7 @@ runs:
         echo "rb_sys_version=$rb_sys_version" >> $GITHUB_OUTPUT
 
     - name: Restore cache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           ${{ env.RB_SYS_DOCK_CACHE_DIR }}
@@ -141,7 +141,7 @@ runs:
         exit "$exitcode"
 
     - name: Save cache
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       if: ${{ (always() && inputs.cache-save-always == 'true') || steps.set-outputs.outputs.build == 0 }}
       with:
         path: |

--- a/post-run/action.yml
+++ b/post-run/action.yml
@@ -16,7 +16,7 @@ inputs:
     default: "false"
 
 runs:
-  using: node20
+  using: node24
   main: main.js
   post: post.js
   post-if: success() || inputs.always == 'true'

--- a/setup-ruby-and-rust/action.yml
+++ b/setup-ruby-and-rust/action.yml
@@ -207,7 +207,7 @@ runs:
         install-path: ${{ github.action_path }}/bin
 
     - name: Cargo registry cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: steps.set-outputs.outputs.cargo-cache != 'false'
       with:
         key: ${{ steps.set-outputs.outputs.cargo-registry-cache-key }}
@@ -219,7 +219,7 @@ runs:
           ~/.cargo/git/db/
 
     - name: Setup base cargo cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: steps.set-outputs.outputs.cargo-cache == 'tarball'
       with:
         key: ${{ steps.set-outputs.outputs.base-cache-key-level-3 }}
@@ -241,7 +241,7 @@ runs:
     - name: Save cargo registry cache
       id: save-cargo-registry-cache
       if: always() && inputs.cache-save-always == 'true' && steps.set-outputs.outputs.cargo-cache != 'false'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         key: ${{ steps.set-outputs.outputs.cargo-registry-cache-key }}
         path: |
@@ -252,7 +252,7 @@ runs:
     - name: Save base cargo cache
       id: save-base-cargo-cache
       if: always() && inputs.cache-save-always == 'true' && steps.set-outputs.outputs.cargo-cache == 'tarball'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         key: ${{ steps.set-outputs.outputs.base-cache-key-level-3 }}
         path: |

--- a/upload-core-dumps/action.yml
+++ b/upload-core-dumps/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: ""
 outputs: {}
 runs:
-  using: node20
+  using: node24
   main: main.js
   post: post.js
   post-if: always()


### PR DESCRIPTION
Hopefully fixes the deprecation warnings from GitHub:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/save@v4, actions/cache@v4, oxidize-rb/actions/post-run@v1. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/